### PR TITLE
Generic typenames output "fix"

### DIFF
--- a/include/Include.h
+++ b/include/Include.h
@@ -34,9 +34,9 @@ namespace source2_gen {
     void main(HMODULE h_module);
 }
 
-constexpr std::string_view kConsoleTitleMessage = {"source2gen :: github.com/neverlosecc/source2gen"};
-constexpr std::string_view kPoweredByMessage = {"Powered by github.com/neverlosecc/source2gen"};
-constexpr std::string_view kCreatedBySource2genMessage = {"Created using source2gen - github.com/neverlosecc/source2gen"};
+inline const char* kConsoleTitleMessage = "source2gen :: github.com/neverlosecc/source2gen";
+inline const char* kPoweredByMessage = "Powered by github.com/neverlosecc/source2gen";
+inline const char* kCreatedBySource2genMessage = "Created using source2gen - github.com/neverlosecc/source2gen";
 
 // source2gen - Source2 games SDK generator
 // Copyright 2023 neverlosecc

--- a/include/tools/codegen.h
+++ b/include/tools/codegen.h
@@ -204,8 +204,19 @@ namespace codegen {
             return push_line(std::format("// {}", text), move_cursor_to_next_line);
         }
 
+        static void replace_all(std::string& text, const std::string& to_remove, const std::string& to_insert) {
+            auto pos = text.find(to_remove);
+            while (pos != std::string::npos) {
+                text.replace(pos, to_remove.length(), to_insert);
+                pos = text.find(to_remove, pos);
+            }
+        }
+
         self_ref prop(const std::string& type_name, const std::string& name, bool move_cursor_to_next_line = true) {
-            const auto line = move_cursor_to_next_line ? std::format("{} {};", type_name, name) : std::format("{} {}; ", type_name, name);
+            auto type_name_fixed = type_name;
+            replace_all(type_name_fixed, "< ", "<");
+            replace_all(type_name_fixed, " >", ">");
+            const auto line = move_cursor_to_next_line ? std::format("{} {};", type_name_fixed, name) : std::format("{} {}; ", type_name_fixed, name);
             return push_line(line, move_cursor_to_next_line);
         }
 

--- a/include/tools/codegen.h
+++ b/include/tools/codegen.h
@@ -5,7 +5,8 @@
 #include <string>
 #include <type_traits>
 
-#include "tools/fnv.h"
+#include "fnv.h"
+#include "string_helpers.h"
 
 namespace codegen {
     constexpr char kTabSym = '\t';
@@ -25,6 +26,13 @@ namespace codegen {
         {128, "uint128_t"},
         {256, "uint256_t"},
         {512, "uint512_t"},
+    };
+    // clang-format on
+
+    // clang-format off
+    inline std::initializer_list<std::pair<std::string, std::string>> kTypeNameReplaceRules = {
+        {"< ", "<"},
+        {" >", ">"},
     };
     // clang-format on
 
@@ -204,18 +212,11 @@ namespace codegen {
             return push_line(std::format("// {}", text), move_cursor_to_next_line);
         }
 
-        static void replace_all(std::string& text, const std::string& to_remove, const std::string& to_insert) {
-            auto pos = text.find(to_remove);
-            while (pos != std::string::npos) {
-                text.replace(pos, to_remove.length(), to_insert);
-                pos = text.find(to_remove, pos);
-            }
-        }
-
         self_ref prop(const std::string& type_name, const std::string& name, bool move_cursor_to_next_line = true) {
             auto type_name_fixed = type_name;
-            replace_all(type_name_fixed, "< ", "<");
-            replace_all(type_name_fixed, " >", ">");
+            for (auto [search, replace] : kTypeNameReplaceRules) {
+                replace_all(type_name_fixed, search, replace);
+            }
             const auto line = move_cursor_to_next_line ? std::format("{} {};", type_name_fixed, name) : std::format("{} {}; ", type_name_fixed, name);
             return push_line(line, move_cursor_to_next_line);
         }

--- a/include/tools/string_helpers.h
+++ b/include/tools/string_helpers.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+
+static void replace_all(std::string& text, const std::string& to_remove, const std::string& to_insert) {
+    auto pos = text.find(to_remove);
+    while (pos != std::string::npos) {
+        text.replace(pos, to_remove.length(), to_insert);
+        pos = text.find(to_remove, pos);
+    }
+}

--- a/src/sdk/sdk.cpp
+++ b/src/sdk/sdk.cpp
@@ -729,7 +729,7 @@ namespace sdk {
             .comment(std::format("Binary: {}", current->GetScopeName()))
             .comment(std::format("Classes count: {}", StringifyUtlTsHashCount(current_classes)))
             .comment(std::format("Enums count: {}", StringifyUtlTsHashCount(current_enums)))
-            .comment(kCreatedBySource2genMessage.data())
+            .comment(kCreatedBySource2genMessage)
             .comment("/////////////////////////////////////////////////////////////")
             .next_line();
 

--- a/src/startup/startup.cpp
+++ b/src/startup/startup.cpp
@@ -82,7 +82,7 @@ namespace source2_gen {
 
     void main(HMODULE module) {
         auto console = std::make_unique<DebugConsole>();
-        console->start(kConsoleTitleMessage.data());
+        console->start(kConsoleTitleMessage);
 
         std::jthread setup_thread(&Setup);
 


### PR DESCRIPTION
Im writing a parser and this change makes things alot easier.
Example:
`CUtlVector< CStrongHandle< InfoForResourceTypeCTextureBase > >`
changes to
`CUtlVector<CStrongHandle<InfoForResourceTypeCTextureBase>>`