### PR TITLE
:circus_tent:

### DIFF
--- a/ACKNOWLEDGEMENTS
+++ b/ACKNOWLEDGEMENTS
@@ -1,0 +1,11 @@
+praydog/Source2Gen, https://github.com/praydog/Source2Gen/blob/43ea0e22dfc0732dc0103fa630f1828da6d5af84/LICENSE.md
+
+    The MIT License (MIT)
+
+    Copyright (c) 2015 praydog
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/include/Include.h
+++ b/include/Include.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 #include <array>
@@ -35,3 +37,21 @@ namespace source2_gen {
 constexpr std::string_view kConsoleTitleMessage = {"source2gen :: github.com/neverlosecc/source2gen"};
 constexpr std::string_view kPoweredByMessage = {"Powered by github.com/neverlosecc/source2gen"};
 constexpr std::string_view kCreatedBySource2genMessage = {"Created using source2gen - github.com/neverlosecc/source2gen"};
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/Include.h
+++ b/include/Include.h
@@ -25,6 +25,7 @@ using namespace std::this_thread;
 #include "tools/codegen.h"
 #include "tools/field_parser.h"
 #include "tools/fnv.h"
+#include "tools/util.h"
 #pragma endregion Tools
 
 namespace source2_gen {

--- a/include/sdk/interfaceregs.h
+++ b/include/sdk/interfaceregs.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 namespace sdk {
@@ -30,3 +32,21 @@ namespace sdk {
         return nullptr;
     }
 } // namespace sdk
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/sdk/interfaces/common/CUtlMap.h
+++ b/include/sdk/interfaces/common/CUtlMap.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 template <typename S, typename T>
@@ -54,3 +56,21 @@ const T& CUtlMap<S, T>::Element(int i) const {
     assert(i < size_);
     return base_[i];
 };
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/sdk/interfaces/common/CUtlMemory.h
+++ b/include/sdk/interfaces/common/CUtlMemory.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 #include "tools/virtual.h"
 #include <sdk/interfaces/tier0/IMemAlloc.h>
@@ -505,3 +507,21 @@ void CUtlMemory<T, I>::Purge(int numElements) {
     m_nAllocationCount = numElements;
     m_pMemory = (T*)GetMemAlloc()->ReAlloc(m_pMemory, m_nAllocationCount * sizeof(T));
 }
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/sdk/interfaces/common/CUtlString.h
+++ b/include/sdk/interfaces/common/CUtlString.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 class CUtlString {
@@ -9,3 +11,21 @@ public:
     CUtlMemory<std::uint8_t> m_Memory;
     int m_nActualLength;
 };
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/sdk/interfaces/common/CUtlTSHash.h
+++ b/include/sdk/interfaces/common/CUtlTSHash.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 using UtlTsHashHandleT = std::uint64_t;
@@ -125,3 +127,21 @@ std::vector<T> CUtlTSHash<T, Keytype>::GetElements(void) {
     }
     return list;
 }
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/sdk/interfaces/common/CUtlVector.h
+++ b/include/sdk/interfaces/common/CUtlVector.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 #include <sdk/interfaces/tier0/IMemAlloc.h>
 
@@ -198,3 +200,21 @@ int CUtlVector<T>::GetOffset(const T& src) const {
     }
     return -1;
 }
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -24,11 +24,6 @@
     #define SCHEMASYSTEM_TYPE_SCOPES_OFFSET 0x4428
     #define SCHEMASYSTEMTYPESCOPE_OFF1 0x4B8
     #define SCHEMASYSTEMTYPESCOPE_OFF2 0x2001
-#elif defined DOTA2
-    #define CSCHEMATYPE_GETSIZES_INDEX 3
-    #define SCHEMASYSTEM_TYPE_SCOPES_OFFSET 0x190
-    #define SCHEMASYSTEMTYPESCOPE_OFF1 0x450
-    #define SCHEMASYSTEMTYPESCOPE_OFF2 0x2804
 #elif defined UNDERLORDS
 // untested, CSchemaType::m_schema_type_ might be wrong
     #define CSCHEMATYPE_GETSIZES_INDEX 5
@@ -44,7 +39,7 @@
     #error "unimplemented"
 #elif defined THE_LAB_ROBOT_REPAIR
     #error "unimplemented"
-#elif defined CSGO2
+#elif defined(CSGO2) || defined(DOTA2)0x47E
     #define CSCHEMATYPE_GETSIZES_INDEX 3
     #define SCHEMASYSTEM_TYPE_SCOPES_OFFSET 0x190
     #define SCHEMASYSTEMTYPESCOPE_OFF1 0x47E

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -4,7 +4,7 @@
 #include <SDK/Interfaces/common/CUtlTSHash.h>
 #include <tools/virtual.h>
 
-#define DOTA2
+#define CSGO2
 
 #ifdef SBOX
 // untested, CSchemaType::m_schema_type_ might be wrong

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -70,7 +70,6 @@ enum SchemaClassFlags_t {
     SCHEMA_CF1_IS_PARENT_CLASSES_PARSED = 32,
     SCHEMA_CF1_IS_LOCAL_TYPE_SCOPE = 64,
     SCHEMA_CF1_IS_GLOBAL_TYPE_SCOPE = 128,
-    SCHEMA_CF1_UNKNOWN1 = 256, // @note: @og: idk
 
 #if defined(CSGO2) || defined(DOTA2)
     SCHEMA_CF1_IS_SCHEMA_VALIDATED = 2048,
@@ -395,7 +394,7 @@ public:
     SchemaMetadataEntryData_t* m_static_metadata; // 0x0048
     CSchemaSystemTypeScope* m_type_scope; // 0x0050
     CSchemaType* m_shema_type; // 0x0058
-    SchemaClassFlags_t m_class_flags; // 0x0060
+    SchemaClassFlags_t m_class_flags : 8; // 0x0060
     std::uint32_t m_sequence; // 0x0064 // @note: @og: idk
     InitializationFn initialization_fn; // 0x0068
 };

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -264,7 +264,7 @@ public:
 class CSchemaType {
 public:
     bool GetSizes(int* out_size1, uint8_t* unk_probably_not_size) {
-        return reinterpret_cast<int(__thiscall*)(void*, int*, uint8_t*)>(_vtable[CSCHEMATYPE_GETSIZES_INDEX])(this, out_size1, unk_probably_not_size);
+        return reinterpret_cast<int(__thiscall*)(void*, int*, uint8_t*)>(vftable_[CSCHEMATYPE_GETSIZES_INDEX])(this, out_size1, unk_probably_not_size);
     }
 public:
     bool GetSize(int* out_size) {
@@ -272,12 +272,12 @@ public:
         return GetSizes(out_size, &smh);
     }
 public:
-    uintptr_t* _vtable; // 0x0000
+    std::uintptr_t* vftable_; // 0x0000
     const char* m_name_; // 0x0008
 
     CSchemaSystemTypeScope* m_type_scope_; // 0x0010
-    uint8_t type_category; // ETypeCategory 0x0018
-    uint8_t atomic_category; // EAtomicCategory 0x0019
+    std::uint8_t type_category; // ETypeCategory 0x0018
+    std::uint8_t atomic_category; // EAtomicCategory 0x0019
 
     // find out to what class pointer points.
     CSchemaType* GetRefClass() const {
@@ -292,24 +292,24 @@ public:
     }
 
     struct array_t {
-        uint32_t array_size;
-        uint32_t unknown;
+        std::uint32_t array_size;
+        std::uint32_t unknown;
         CSchemaType* element_type_;
     };
 
     struct atomic_t { // same goes for CollectionOfT
-        uint64_t gap[2];
+        std::uint64_t gap[2];
         CSchemaType* template_typename;
     };
 
     struct atomic_tt {
-        uint64_t gap[2];
+        std::uint64_t gap[2];
         CSchemaType* templates[2];
     };
 
     struct atomic_i {
-        uint64_t gap[2];
-        uint64_t integer;
+        std::uint64_t gap[2];
+        std::uint64_t integer;
     };
 
     // this union depends on CSchema implementation, all members above

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -235,7 +235,6 @@ struct SchemaEnumeratorInfoData_t {
 
     std::int32_t m_metadata_size;
     SchemaMetadataEntryData_t* m_metadata;
-    //char pad_0x0010[0x10]; // 0x0010
 };
 
 class CSchemaEnumInfo {

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -47,8 +47,9 @@
 #elif defined CSGO2
     #define CSCHEMATYPE_GETSIZES_INDEX 3
     #define SCHEMASYSTEM_TYPE_SCOPES_OFFSET 0x190
-    #define SCHEMASYSTEMTYPESCOPE_OFF1 0x450
-    #define SCHEMASYSTEMTYPESCOPE_OFF2 0x2804
+    #define SCHEMASYSTEMTYPESCOPE_OFF1 0x47E
+    #define SCHEMASYSTEMTYPESCOPE_OFF2 0x2808
+    #define SCHEMASYSTEM_FIND_DECLARED_CLASS_TYPE 2
 #endif
 
 class CSchemaClassInfo;
@@ -311,7 +312,14 @@ private:
 class CSchemaSystemTypeScope {
 public:
     CSchemaClassInfo* FindDeclaredClass(const char* class_name) {
+#if defined(SCHEMASYSTEM_FIND_DECLARED_CLASS_TYPE) && SCHEMASYSTEM_FIND_DECLARED_CLASS_TYPE == 2
+        CSchemaClassInfo* class_info;
+
+        Virtual::Get<void(__thiscall*)(void*, CSchemaClassInfo**, const char*)>(this, 2)(this, &class_info, class_name);
+        return class_info;
+#else
         return Virtual::Get<CSchemaClassInfo*(__thiscall*)(void*, const char*)>(this, 2)(this, class_name);
+#endif
     }
 
     CSchemaEnumBinding* FindDeclaredEnum(const char* name) {
@@ -353,9 +361,9 @@ private:
     char pad_0x0000[0x8]; // 0x0000
     std::array<char, 256> m_name_ = {};
     char pad_0x0108[SCHEMASYSTEMTYPESCOPE_OFF1]; // 0x0108
-    CUtlTSHash<CSchemaClassBinding*> m_classes_; // 0x0558
-    char pad_0x0594[SCHEMASYSTEMTYPESCOPE_OFF2]; // 0x0594
-    CUtlTSHash<CSchemaEnumBinding*> m_enumes_; // 0x2DA0
+    CUtlTSHash<CSchemaClassBinding*> m_classes_; // 0x0588
+    char pad_0x0594[SCHEMASYSTEMTYPESCOPE_OFF2]; // 0x05C8
+    CUtlTSHash<CSchemaEnumBinding*> m_enumes_; // 0x2DD0
 private:
     static constexpr unsigned int s_class_list = 0x580;
 };

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -525,8 +525,7 @@ public:
         return Virtual::Get<const char*(__thiscall*)(void*, CSchemaEnumBinding*)>(this, 25)(this, class_info);
     }
 
-    bool SchemaSystemIsReady()
-    {
+    bool SchemaSystemIsReady() {
         return Virtual::Get<bool(__thiscall*)(void*)>(this, 26)(this);
     }
 

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -251,13 +251,13 @@ struct SchemaClassFieldData_t {
     SchemaMetadataEntryData_t* m_metadata; // 0x0018
 };
 
-struct CSchemaClassInfoField_t {
+struct SchemaFieldMetadataOverrideData_t {
     char pad_0000[8]; // 0x0000
     SchemaString_t m_name; // 0x0008
     std::uint32_t m_single_inheritance_offset; // 0x0010
     char pad_0014[84]; // 0x0014
 }; // Size: 0x0068
-static_assert(sizeof(CSchemaClassInfoField_t) == 0x68);
+static_assert(sizeof(SchemaFieldMetadataOverrideData_t) == 0x68);
 
 struct SchemaStaticFieldData_t {
     const char* name; // 0x0000
@@ -271,8 +271,8 @@ struct SchemaBaseClassInfoData_t {
     CSchemaClassInfo* m_class;
 };
 
-struct CSchemaClassInfoFieldsData_t {
-    CSchemaClassInfoField_t* m_field;
+struct SchemaFieldMetadataOverrideSetData_t {
+    SchemaFieldMetadataOverrideData_t* m_field;
     std::int32_t m_size;
 };
 
@@ -305,7 +305,7 @@ public:
     SchemaClassFieldData_t* m_fields; // 0x0028
     SchemaStaticFieldData_t* m_static_fields; // 0x0030
     SchemaBaseClassInfoData_t* m_schema_parent; // 0x0038
-    CSchemaClassInfoFieldsData_t* m_fields_backup; // 0x0040 // @note: @og: sometimes it duplicates m_fields, cant find where it being used
+    SchemaFieldMetadataOverrideSetData_t* m_field_metadata_overrides; // 0x0040 // @note: @og: based on praydog sdk gen
     SchemaMetadataEntryData_t* m_metadata; // 0x0048
     CSchemaSystemTypeScope* m_type_scope; // 0x0050
     CSchemaType* m_shema_type; // 0x0058

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -249,6 +249,14 @@ struct SchemaClassFieldData_t {
     SchemaMetadataEntryData_t* m_metadata; // 0x0018
 };
 
+struct CSchemaClassInfoField_t {
+    char pad_0000[8]; // 0x0000
+    SchemaString_t m_name; // 0x0008
+    std::uint32_t m_single_inheritance_offset; // 0x0010
+    char pad_0014[84]; // 0x0014
+}; // Size: 0x0068
+static_assert(sizeof(CSchemaClassInfoField_t) == 0x68);
+
 struct SchemaStaticFieldData_t {
     const char* name; // 0x0000
     CSchemaType* m_type; // 0x0008
@@ -261,9 +269,11 @@ struct SchemaBaseClassInfoData_t {
     CSchemaClassInfo* m_class;
 };
 
-constexpr auto gay = sizeof(bool);
+struct CSchemaClassInfoFieldsData_t {
+    CSchemaClassInfoField_t* m_field;
+    std::int32_t m_size;
+};
 
-// Classes
 struct SchemaClassInfoData_t {
 private:
     enum class SchemaClassInitialization_t : std::int32_t {
@@ -279,13 +289,10 @@ private:
     using InitializationFn = void(*)(SchemaClassInitialization_t, SchemaClassInfoData_t*, SchemaClassInfoData_t*);
 
 public:
-    SchemaClassInfoData_t* m_parent; // 0x0000
-
+    SchemaClassInfoData_t* m_self; // 0x0000
     const char* m_name; // 0x0008
-    char* m_module; // 0x0010
-
+    const char* m_module; // 0x0010
     int m_size; // 0x0018
-
     std::int16_t m_fields_size; // 0x001C
     std::int16_t m_static_size; // 0x001E
     std::int16_t m_metadata_size; // 0x0020
@@ -293,18 +300,15 @@ public:
     std::uint8_t m_has_base_class; // 0x0023
     std::int16_t m_total_class_size; // 0x0024 // @note: @og: if there no derived or base class then it will be 1 otherwise derived class size + 1.
     std::int16_t m_derived_class_size; // 0x0026
-
     SchemaClassFieldData_t* m_fields; // 0x0028
     SchemaStaticFieldData_t* m_static_fields; // 0x0030
     SchemaBaseClassInfoData_t* m_schema_parent; // 0x0038
-
-    char pad_0x0038[8];
-
+    CSchemaClassInfoFieldsData_t* m_fields_backup; // 0x0040 // @note: @og: sometimes it duplicates m_fields, cant find where it being used
     SchemaMetadataEntryData_t* m_metadata; // 0x0048
     CSchemaSystemTypeScope* m_type_scope; // 0x0050
     CSchemaType* m_shema_type; // 0x0058
     SchemaClassFlags_t m_class_flags; // 0x0060
-    std::uint32_t m_i_unk_1; // 0x0064
+    std::uint32_t m_sequence; // 0x0064 // @note: @og: idk
     InitializationFn initialization_fn; // 0x0068
 
 public:

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 /**
  * =============================================================================
  * Source2Gen
@@ -651,3 +653,21 @@ public:
         return sdk::GetInterface<CSchemaSystem>("schemasystem.dll", "SchemaSystem_0");
     }
 };
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -4,7 +4,7 @@
 #include <SDK/Interfaces/common/CUtlTSHash.h>
 #include <tools/virtual.h>
 
-#define DOTA2
+#define CSGO2
 
 #ifdef SBOX
 // untested, CSchemaType::m_schema_type_ might be wrong
@@ -61,8 +61,11 @@ enum SchemaClassFlags_t {
     SCHEMA_CF1_IS_ABSTRACT = 2,
     SCHEMA_CF1_HAS_TRIVIAL_CONSTRUCTOR = 4,
     SCHEMA_CF1_HAS_TRIVIAL_DESTRUCTOR = 8,
+    SCHEMA_CF1_HAS_NOSCHEMA_MEMBERS = 16, // @note: @og: aint sure, since I cant find any class with these flags
+    SCHEMA_CF1_UNKNOWN = 32, // @note: @og: in old source2gen it was constructor like methods but now I cant find any reference to what it is
     SCHEMA_CF1_IS_LOCAL_TYPE_SCOPE = 64,
     SCHEMA_CF1_IS_GLOBAL_TYPE_SCOPE = 128,
+    SCHEMA_CF1_UNKNOWN2 = 256, // @note: @og: same as above, idk what it is
     SCHEMA_CF1_IS_NOSCHEMA_CLASS = 2048,
 };
 
@@ -287,10 +290,10 @@ public:
     SchemaMetadataEntryData_t* m_metadata; // 0x0048
     CSchemaSystemTypeScope* m_type_scope; // 0x0050
     CSchemaType* m_shema_type; // 0x0058
-    SchemaClassFlags_t m_class_flags : 8; // 0x0060
+    SchemaClassFlags_t m_class_flags; // 0x0060
 
 public:
-    std::uint8_t GetAligment() {
+    [[nodiscard]] std::uint8_t GetAligment() const {
         return m_align_of == std::numeric_limits<std::uint8_t>::max() ? 4 : m_align_of;
     }
 };

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -52,7 +52,6 @@ class CSchemaSystemTypeScope;
 class CSchemaType;
 
 struct SchemaMetadataEntryData_t;
-struct SchemaMetadataSetData_t;
 struct SchemaClassInfoData_t;
 
 using SchemaString_t = const char*;
@@ -62,10 +61,9 @@ enum SchemaClassFlags_t {
     SCHEMA_CF1_IS_ABSTRACT = 2,
     SCHEMA_CF1_HAS_TRIVIAL_CONSTRUCTOR = 4,
     SCHEMA_CF1_HAS_TRIVIAL_DESTRUCTOR = 8,
-    SCHEMA_CLASS_TEMP_HACK_HAS_NOSCHEMA_MEMBERS = 16,
-    SCHEMA_CLASS_TEMP_HACK_HAS_CONSTRUCTOR_LIKE_METHODS = 32,
-    SCHEMA_CLASS_TEMP_HACK_HAS_DESTRUCTOR_LIKE_METHODS = 64,
-    SCHEMA_CLASS_IS_NOSCHEMA_CLASS = 128,
+    SCHEMA_CF1_IS_LOCAL_TYPE_SCOPE = 64,
+    SCHEMA_CF1_IS_GLOBAL_TYPE_SCOPE = 128,
+    SCHEMA_CF1_IS_NOSCHEMA_CLASS = 2048,
 };
 
 enum ETypeCategory {
@@ -110,11 +108,12 @@ struct CSchemaVarName {
 
 struct CSchemaNetworkValue {
     union {
-        const char* m_sz_value;
+        const char* m_p_sz_value;
         int m_n_value;
         float m_f_value;
         std::uintptr_t m_p_value;
-        CSchemaVarName* m_var_name;
+        CSchemaVarName m_var_value;
+        std::array<char, 32> m_sz_value;
     };
 };
 
@@ -132,19 +131,6 @@ struct CSchemaClassBinding {
 struct SchemaMetadataEntryData_t {
     SchemaString_t m_name;
     CSchemaNetworkValue* m_value;
-    // CSchemaType* m_pDataType;
-    // void* unaccounted;
-};
-
-struct SchemaClassMetadataEntryData_t {
-    SchemaString_t m_name;
-    CSchemaNetworkValue m_value;
-    // CSchemaType* m_pDataType;
-    // void* unaccounted;
-};
-
-struct SchemaMetadataSetData_t {
-    SchemaClassMetadataEntryData_t m_entry;
 };
 
 struct SchemaEnumeratorInfoData_t {
@@ -298,7 +284,7 @@ public:
 
     char pad_0x0038[8];
 
-    SchemaMetadataSetData_t* m_metadata; // 0x0048
+    SchemaMetadataEntryData_t* m_metadata; // 0x0048
     CSchemaSystemTypeScope* m_type_scope; // 0x0050
     CSchemaType* m_shema_type; // 0x0058
     SchemaClassFlags_t m_class_flags : 8; // 0x0060

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -4,7 +4,7 @@
 #include <SDK/Interfaces/common/CUtlTSHash.h>
 #include <tools/virtual.h>
 
-#define DOTA2
+#define CSGO2
 
 #ifdef SBOX
 // untested, CSchemaType::m_schema_type_ might be wrong
@@ -47,6 +47,7 @@
     #define SCHEMASYSTEM_FIND_DECLARED_CLASS_TYPE 2
 #endif
 
+class ISaveRestoreOps;
 class CSchemaClassInfo;
 class CSchemaSystemTypeScope;
 class CSchemaType;
@@ -87,6 +88,92 @@ enum EAtomicCategory {
     Atomic_TT,
     Atomic_I,
     Atomic_None
+};
+
+// Registered binary: schemasystem.dll (project 'schemasystem')
+// Alignment: 1
+// Size: 0x50
+enum class fieldtype_t : uint8_t {
+    FIELD_VOID = 0x0,
+    FIELD_FLOAT32 = 0x1,
+    FIELD_STRING = 0x2,
+    FIELD_VECTOR = 0x3,
+    FIELD_QUATERNION = 0x4,
+    FIELD_INT32 = 0x5,
+    FIELD_BOOLEAN = 0x6,
+    FIELD_INT16 = 0x7,
+    FIELD_CHARACTER = 0x8,
+    FIELD_COLOR32 = 0x9,
+    FIELD_EMBEDDED = 0xa,
+    FIELD_CUSTOM = 0xb,
+    FIELD_CLASSPTR = 0xc,
+    FIELD_EHANDLE = 0xd,
+    FIELD_POSITION_VECTOR = 0xe,
+    FIELD_TIME = 0xf,
+    FIELD_TICK = 0x10,
+    FIELD_SOUNDNAME = 0x11,
+    FIELD_INPUT = 0x12,
+    FIELD_FUNCTION = 0x13,
+    FIELD_VMATRIX = 0x14,
+    FIELD_VMATRIX_WORLDSPACE = 0x15,
+    FIELD_MATRIX3X4_WORLDSPACE = 0x16,
+    FIELD_INTERVAL = 0x17,
+    FIELD_UNUSED = 0x18,
+    FIELD_VECTOR2D = 0x19,
+    FIELD_INT64 = 0x1a,
+    FIELD_VECTOR4D = 0x1b,
+    FIELD_RESOURCE = 0x1c,
+    FIELD_TYPEUNKNOWN = 0x1d,
+    FIELD_CSTRING = 0x1e,
+    FIELD_HSCRIPT = 0x1f,
+    FIELD_VARIANT = 0x20,
+    FIELD_UINT64 = 0x21,
+    FIELD_FLOAT64 = 0x22,
+    FIELD_POSITIVEINTEGER_OR_NULL = 0x23,
+    FIELD_HSCRIPT_NEW_INSTANCE = 0x24,
+    FIELD_UINT32 = 0x25,
+    FIELD_UTLSTRINGTOKEN = 0x26,
+    FIELD_QANGLE = 0x27,
+    FIELD_NETWORK_ORIGIN_CELL_QUANTIZED_VECTOR = 0x28,
+    FIELD_HMATERIAL = 0x29,
+    FIELD_HMODEL = 0x2a,
+    FIELD_NETWORK_QUANTIZED_VECTOR = 0x2b,
+    FIELD_NETWORK_QUANTIZED_FLOAT = 0x2c,
+    FIELD_DIRECTION_VECTOR_WORLDSPACE = 0x2d,
+    FIELD_QANGLE_WORLDSPACE = 0x2e,
+    FIELD_QUATERNION_WORLDSPACE = 0x2f,
+    FIELD_HSCRIPT_LIGHTBINDING = 0x30,
+    FIELD_V8_VALUE = 0x31,
+    FIELD_V8_OBJECT = 0x32,
+    FIELD_V8_ARRAY = 0x33,
+    FIELD_V8_CALLBACK_INFO = 0x34,
+    FIELD_UTLSTRING = 0x35,
+    FIELD_NETWORK_ORIGIN_CELL_QUANTIZED_POSITION_VECTOR = 0x36,
+    FIELD_HRENDERTEXTURE = 0x37,
+    FIELD_HPARTICLESYSTEMDEFINITION = 0x38,
+    FIELD_UINT8 = 0x39,
+    FIELD_UINT16 = 0x3a,
+    FIELD_CTRANSFORM = 0x3b,
+    FIELD_CTRANSFORM_WORLDSPACE = 0x3c,
+    FIELD_HPOSTPROCESSING = 0x3d,
+    FIELD_MATRIX3X4 = 0x3e,
+    FIELD_SHIM = 0x3f,
+    FIELD_CMOTIONTRANSFORM = 0x40,
+    FIELD_CMOTIONTRANSFORM_WORLDSPACE = 0x41,
+    FIELD_ATTACHMENT_HANDLE = 0x42,
+    FIELD_AMMO_INDEX = 0x43,
+    FIELD_CONDITION_ID = 0x44,
+    FIELD_AI_SCHEDULE_BITS = 0x45,
+    FIELD_MODIFIER_HANDLE = 0x46,
+    FIELD_ROTATION_VECTOR = 0x47,
+    FIELD_ROTATION_VECTOR_WORLDSPACE = 0x48,
+    FIELD_HVDATA = 0x49,
+    FIELD_SCALE32 = 0x4a,
+    FIELD_STRING_AND_TOKEN = 0x4b,
+    FIELD_ENGINE_TIME = 0x4c,
+    FIELD_ENGINE_TICK = 0x4d,
+    FIELD_WORLD_GROUP_ID = 0x4e,
+    FIELD_TYPECOUNT = 0x4f,
 };
 
 template <typename T>
@@ -252,10 +339,18 @@ struct SchemaClassFieldData_t {
 };
 
 struct SchemaFieldMetadataOverrideData_t {
-    char pad_0000[8]; // 0x0000
-    SchemaString_t m_name; // 0x0008
+    fieldtype_t m_field_type; //0x0000
+    char pad_0001[7]; // 0x0001
+    SchemaString_t m_field_name; // 0x0008
     std::uint32_t m_single_inheritance_offset; // 0x0010
-    char pad_0014[84]; // 0x0014
+    std::int32_t m_field_count; // 0x0014 // @note: @og: if its array or smth like this it will point to count of array
+    std::int32_t m_i_unk_1; // 0x0018
+    char pad_001C[12]; // 0x001C
+    ISaveRestoreOps* m_def_save_restore_ops; // 0x0028
+    char pad_0030[16]; // 0x0030
+    std::uint32_t m_align; // 0x0040
+    char pad_0044[36]; // 0x0044
+
 }; // Size: 0x0068
 static_assert(sizeof(SchemaFieldMetadataOverrideData_t) == 0x68);
 
@@ -272,7 +367,7 @@ struct SchemaBaseClassInfoData_t {
 };
 
 struct SchemaFieldMetadataOverrideSetData_t {
-    SchemaFieldMetadataOverrideData_t* m_field;
+    SchemaFieldMetadataOverrideData_t* m_metadata_override_data;
     std::int32_t m_size;
 };
 
@@ -305,7 +400,7 @@ public:
     SchemaClassFieldData_t* m_fields; // 0x0028
     SchemaStaticFieldData_t* m_static_fields; // 0x0030
     SchemaBaseClassInfoData_t* m_schema_parent; // 0x0038
-    SchemaFieldMetadataOverrideSetData_t* m_field_metadata_overrides; // 0x0040 // @note: @og: based on praydog sdk gen
+    SchemaFieldMetadataOverrideSetData_t* m_field_metadata_overrides; // 0x0040
     SchemaMetadataEntryData_t* m_metadata; // 0x0048
     CSchemaSystemTypeScope* m_type_scope; // 0x0050
     CSchemaType* m_shema_type; // 0x0058

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -4,7 +4,7 @@
 #include <SDK/Interfaces/common/CUtlTSHash.h>
 #include <tools/virtual.h>
 
-#define CSGO2
+#define DOTA2
 
 #ifdef SBOX
 // untested, CSchemaType::m_schema_type_ might be wrong
@@ -146,7 +146,9 @@ struct SchemaEnumeratorInfoData_t {
         unsigned long long m_value;
     };
 
-    char pad_0x0010[0x10]; // 0x0010
+    std::int32_t m_metadata_size;
+    SchemaMetadataEntryData_t* m_metadata;
+    //char pad_0x0010[0x10]; // 0x0010
 };
 
 class CSchemaEnumInfo {

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -1,3 +1,10 @@
+/**
+ * =============================================================================
+ * Source2Gen
+ * Copyright (C) 2023 neverlose (https://github.com/neverlosecc/source2gen)
+ * =============================================================================
+ **/
+
 #pragma once
 
 #include <Include.h>
@@ -628,6 +635,7 @@ public:
     [[nodiscard]] std::int32_t GetIgnoredBytes() const {
         return m_ignored_bytes_;
     }
+
 private:
     char pad_0x0000[SCHEMASYSTEM_TYPE_SCOPES_OFFSET]; // 0x0000
     CUtlVector<CSchemaSystemTypeScope*> m_type_scopes_ = {}; // SCHEMASYSTEM_TYPE_SCOPES_OFFSET

--- a/include/sdk/interfaces/tier0/IMemAlloc.h
+++ b/include/sdk/interfaces/tier0/IMemAlloc.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 #pragma warning(push)
@@ -32,3 +34,21 @@ void __CRTDECL operator delete(void* p, std::size_t s);
 void __CRTDECL operator delete[](void* p);
 
 #pragma warning(pop)
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/sdk/sdk.h
+++ b/include/sdk/sdk.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 #include <Include.h>
@@ -18,3 +20,21 @@ namespace sdk {
 
     void GenerateTypeScopeSdk(CSchemaSystemTypeScope* current);
 } // namespace sdk
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/sdk/sdk.h
+++ b/include/sdk/sdk.h
@@ -7,8 +7,8 @@
 #include <sdk/interfaces/common/CUtlMap.h>
 #include <sdk/interfaces/common/CUtlMemory.h>
 #include <sdk/interfaces/common/CUtlString.h>
-#include <sdk/interfaces/common/CUtlTSHash.h>
 #include <sdk/interfaces/common/CUtlVector.h>
+#include <sdk/interfaces/common/CUtlTSHash.h>
 
 #include <sdk/interfaceregs.h>
 #include <sdk/interfaces/schemasystem/Schema.h>

--- a/include/tools/codegen.h
+++ b/include/tools/codegen.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 #include <cstdint>
 #include <set>
@@ -315,3 +317,21 @@ namespace codegen {
         return generator_t{};
     }
 } // namespace codegen
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/tools/console/console.h
+++ b/include/tools/console/console.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 #include "../../Include.h"
@@ -154,3 +156,21 @@ private:
     HANDLE old_err_ = nullptr;
     HANDLE old_in_ = nullptr;
 };
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/tools/field_parser.h
+++ b/include/tools/field_parser.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #include <cstdint>
 #include <string>
 
@@ -148,3 +150,21 @@ namespace field_parser {
         return result;
     }
 } // namespace field_parser
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/tools/fnv.h
+++ b/include/tools/fnv.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 #include <cstdint>
 #include <type_traits>
@@ -106,3 +108,21 @@ using fnv = ::detail::FnvHash<sizeof(void*) * 8>;
 #define FNV(str) (std::integral_constant<fnv::hash, fnv::hash_constexpr(str)>::value)
 #define FNV32(str) (std::integral_constant<fnv32::hash, fnv32::hash_constexpr(str)>::value)
 #define FNV64(str) (std::integral_constant<fnv64::hash, fnv64::hash_constexpr(str)>::value)
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/tools/util.h
+++ b/include/tools/util.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 namespace util { 
@@ -14,3 +16,21 @@ namespace util {
         return std::to_string(num);
     }
 };
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/include/tools/util.h
+++ b/include/tools/util.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace util { 
+	inline std::string_view PrettifyNum(int num) {
+        static const auto fn = reinterpret_cast<const char* (*)(int)>(GetProcAddress(GetModuleHandleA("tier0.dll"), "V_PrettifyNum"));
+
+        if (fn) {
+            std::string_view res = fn(num);
+            if (!res.empty()) {
+                return res;
+            }
+        }
+
+        return std::to_string(num);
+    }
+};

--- a/include/tools/virtual.h
+++ b/include/tools/virtual.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #pragma once
 
 #include <Include.h>
@@ -18,3 +20,21 @@ namespace Virtual {
         *reinterpret_cast<T*>(location) = data;
     }
 } // namespace Virtual
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/scripts/license_template.txt
+++ b/scripts/license_template.txt
@@ -1,0 +1,15 @@
+source2gen - Source2 games SDK generator
+Copyright %year% neverlosecc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/scripts/license_template_header.txt
+++ b/scripts/license_template_header.txt
@@ -1,0 +1,2 @@
+Copyright (C) %year% neverlosecc
+See end of file for extended copyright information.

--- a/scripts/update_copyrights.py
+++ b/scripts/update_copyrights.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+from datetime import datetime
+from typing import List
+
+
+EXTENSIONS = ['.cpp', '.cc', '.cxx', '.c', '.hpp', '.h']
+
+
+current_dir = Path(__file__).parent
+current_year = str(datetime.utcnow().year)
+
+
+def format_buffer(s: str) -> str:
+    return s.replace('%year%', current_year)
+
+
+with open(current_dir / 'license_template.txt', 'r') as f:
+    license_template = format_buffer(f.read())
+
+with open(current_dir / 'license_template_header.txt', 'r') as f:
+    license_template_header = format_buffer(f.read())
+
+
+def get_comment_chr(file_name: str) -> str:
+    return '#' if file_name.endswith('.py') else '//'
+
+
+def to_comments(file_name: str, buffer: str) -> str:
+    comment_chr: str = get_comment_chr(file_name)
+    return '\n'.join([f'{comment_chr} {line}'.strip() for line in buffer.splitlines()])
+
+
+def remove_copyright(file_name: str, lines: List[str]) -> List[str]:
+    comment_chr: str = get_comment_chr(file_name)
+
+    ends_at: int = 0
+    for i, line in enumerate(lines):
+        if line.startswith(comment_chr):
+            continue
+
+        ends_at = max(0, i)
+        break
+
+    starts_at_bottom: int = len(lines) - 1
+    for i, line in reversed(list(enumerate(lines))):
+        if line.startswith(comment_chr) or line == '':
+            continue
+
+        starts_at_bottom = min(len(lines) - 1, i + 1)
+        break
+
+    return lines[ends_at:starts_at_bottom]
+
+
+def append_copyright_to(p: Path) -> None:
+    header = to_comments(p.name, license_template_header).splitlines()
+    full = to_comments(p.name, license_template).splitlines()
+
+    with open(p, 'r') as f:
+        file_lines = f.read().splitlines()
+
+    def _is_copyrighted() -> bool:
+        return file_lines[0].split(current_year)[0] == header[0].split(current_year)[0]
+    
+    is_copyrighted = _is_copyrighted()
+    if is_copyrighted:
+        file_lines = remove_copyright(p.name, file_lines)
+
+    file_lines = header + file_lines + ['\n'] + full + ['\n']
+    with open(p, 'w') as f:
+        f.write('\n'.join(file_lines))
+
+
+def iter_dir(p: Path) -> None:
+    for file in p.iterdir():
+        if file.is_dir():
+            iter_dir(file)
+            continue
+
+        for ext in EXTENSIONS:
+            if not file.name.endswith(ext):
+                continue
+
+            append_copyright_to(file)
+            break
+
+
+if __name__ == '__main__':
+    iter_dir(Path(__file__).parent.parent)
+

--- a/src/sdk/interfaces/tier0/IMemAlloc.cpp
+++ b/src/sdk/interfaces/tier0/IMemAlloc.cpp
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #include <Include.h>
 #include <SDK/Interfaces/tier0/IMemAlloc.h>
 
@@ -27,3 +29,21 @@ void __CRTDECL operator delete(void* p, std::size_t size) {
 void __CRTDECL operator delete[](void* p) throw() {
     GetMemAlloc()->Free(p);
 }
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/src/sdk/sdk.cpp
+++ b/src/sdk/sdk.cpp
@@ -70,12 +70,14 @@ namespace sdk {
                 builder.comment("Has Trivial Constructor");
             if ((class_info->m_class_flags & SCHEMA_CF1_HAS_TRIVIAL_DESTRUCTOR) != 0)
                 builder.comment("Has Trivial Destructor");
+            if ((class_info->m_class_flags & SCHEMA_CF1_HAS_NOSCHEMA_MEMBERS) != 0)
+                builder.comment("Has No Schema Members");
             if ((class_info->m_class_flags & SCHEMA_CF1_IS_LOCAL_TYPE_SCOPE) != 0)
                 builder.comment("Is Local Type Scope");
             if ((class_info->m_class_flags & SCHEMA_CF1_IS_GLOBAL_TYPE_SCOPE) != 0)
                 builder.comment("Is Global Type Scope");
             if ((class_info->m_class_flags & SCHEMA_CF1_IS_NOSCHEMA_CLASS) != 0)
-                builder.comment("Not schema class");
+                builder.comment("Not Schema Class");
             if (class_info->m_has_base_class == 1)
                 builder.comment("Has Base Class");
 

--- a/src/sdk/sdk.cpp
+++ b/src/sdk/sdk.cpp
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #include "sdk/sdk.h"
 #include <filesystem>
 #include <set>
@@ -623,3 +625,21 @@ namespace sdk {
         f.close();
     }
 } // namespace sdk
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/src/sdk/sdk.cpp
+++ b/src/sdk/sdk.cpp
@@ -122,7 +122,7 @@ namespace sdk {
                 auto metadata = class_info->m_metadata[i];
 
                 if (const auto value = get_metadata_type(metadata); !value.empty())
-                    builder.comment(std::format("{} {}", metadata.m_name, value));
+                    builder.comment(std::format("{} \"{}\"", metadata.m_name, value));
                 else
                     builder.comment(metadata.m_name);
             }

--- a/src/sdk/sdk.cpp
+++ b/src/sdk/sdk.cpp
@@ -7,9 +7,9 @@ namespace {
     using namespace std::string_view_literals;
 
     constexpr std::string_view kOutDirName = "sdk"sv;
-    constexpr std::initializer_list<std::string_view> kIncludePaths = {"<cstdint>"sv, "\"!GlobalTypes.hpp\""sv};
+    constinit std::array include_paths = {"<cstdint>"sv, "\"!GlobalTypes.hpp\""sv};
 
-    constexpr std::initializer_list<fnv32::hash> kStringMetadataEntries = {
+    constinit std::array string_metadata_entries = {
         FNV32("MNetworkChangeCallback"),  FNV32("MPropertyFriendlyName"), FNV32("MPropertyDescription"),
         FNV32("MPropertyAttributeRange"), FNV32("MPropertyStartGroup"),   FNV32("MPropertyAttributeChoiceName"),
         FNV32("MPropertyGroupName"),      FNV32("MNetworkUserGroup"),     FNV32("MNetworkAlias"),
@@ -19,21 +19,21 @@ namespace {
         FNV32("MVDataUniqueMonotonicInt"), FNV32("MScriptDescription")
     };
 
-    constexpr std::initializer_list<fnv32::hash> kStringClassMetadataEntries = {
+    constinit std::array string_class_metadata_entries = {
         FNV32("MResourceTypeForInfoType"),
     };
 
-    constexpr std::initializer_list<fnv32::hash> kVarNameStringClassMetadataEntries = {
+    constinit std::array var_name_string_class_metadata_entries = {
         FNV32("MNetworkVarNames"), FNV32("MNetworkOverride"), FNV32("MNetworkVarTypeOverride"),
     };
 
-    constexpr std::initializer_list<fnv32::hash> kVarStringClassMetadataEntries = {
+    constinit std::array var_string_class_metadata_entries = {
         FNV32("MPropertyArrayElementNameKey"), FNV32("MPropertyFriendlyName"),      FNV32("MPropertyDescription"),
         FNV32("MNetworkExcludeByName"),        FNV32("MNetworkExcludeByUserGroup"), FNV32("MNetworkIncludeByName"),
         FNV32("MNetworkIncludeByUserGroup"),   FNV32("MNetworkUserGroupProxy"),     FNV32("MNetworkReplayCompatField"), 
     };
 
-    constexpr std::initializer_list<fnv32::hash> kIntegerMetadataEntries = {
+    constinit std::array integer_metadata_entries = {
         FNV32("MNetworkVarEmbeddedFieldOffsetDelta"),
         FNV32("MNetworkBitCount"),
         FNV32("MNetworkPriority"),
@@ -43,7 +43,7 @@ namespace {
         FNV32("MNetworkEncodeFlags"),
     };
 
-    constexpr std::initializer_list<fnv32::hash> kFloatMetadataEntries = {
+    constinit std::array float_metadata_entries = {
         FNV32("MNetworkMinValue"),
         FNV32("MNetworkMaxValue"),
     };
@@ -60,11 +60,11 @@ namespace {
         const auto value_hash_name = fnv32::hash_runtime(metadata_entry.m_name);
 
         // clang-format off
-        if (std::find(kStringMetadataEntries.begin(), kStringMetadataEntries.end(), value_hash_name) != kStringMetadataEntries.end())
+        if (std::find(string_metadata_entries.begin(), string_metadata_entries.end(), value_hash_name) != string_metadata_entries.end())
             value = metadata_entry.m_value->m_p_sz_value;
-        else if (std::find(kIntegerMetadataEntries.begin(), kIntegerMetadataEntries.end(), value_hash_name) != kIntegerMetadataEntries.end())
+        else if (std::find(integer_metadata_entries.begin(), integer_metadata_entries.end(), value_hash_name) != integer_metadata_entries.end())
             value = std::to_string(metadata_entry.m_value->m_n_value);
-        else if (std::find(kFloatMetadataEntries.begin(), kFloatMetadataEntries.end(), value_hash_name) != kFloatMetadataEntries.end())
+        else if (std::find(float_metadata_entries.begin(), float_metadata_entries.end(), value_hash_name) != float_metadata_entries.end())
             value = std::to_string(metadata_entry.m_value->m_f_value);
         // clang-format on
 
@@ -99,7 +99,7 @@ namespace sdk {
                 const auto value_hash_name = fnv32::hash_runtime(metadata_entry.m_name);
 
                 // clang-format off
-                if (std::find(kVarNameStringClassMetadataEntries.begin(), kVarNameStringClassMetadataEntries.end(), value_hash_name) != kVarNameStringClassMetadataEntries.end())
+                if (std::find(var_name_string_class_metadata_entries.begin(), var_name_string_class_metadata_entries.end(), value_hash_name) != var_name_string_class_metadata_entries.end())
                 {
                     const auto &var_value = metadata_entry.m_value->m_var_value;
                     if (var_value.m_type && var_value.m_name)
@@ -109,9 +109,9 @@ namespace sdk {
                     else if (!var_value.m_name && var_value.m_type)
                         value = var_value.m_type;
                  }
-                else if (std::find(kStringClassMetadataEntries.begin(), kStringClassMetadataEntries.end(), value_hash_name) != kStringClassMetadataEntries.end())
+                else if (std::find(string_class_metadata_entries.begin(), string_class_metadata_entries.end(), value_hash_name) != string_class_metadata_entries.end())
                     value = metadata_entry.m_value->m_sz_value.data();
-                else if (std::find(kVarStringClassMetadataEntries.begin(), kVarStringClassMetadataEntries.end(), value_hash_name) != kVarStringClassMetadataEntries.end())
+                else if (std::find(var_string_class_metadata_entries.begin(), var_string_class_metadata_entries.end(), value_hash_name) != var_string_class_metadata_entries.end())
                     value = metadata_entry.m_value->m_p_sz_value;
                 // clang-format on
 
@@ -592,7 +592,7 @@ namespace sdk {
 
         // @note: @es3n1n: include files
         //
-        for (auto&& include_path : kIncludePaths)
+        for (auto&& include_path : include_paths)
             builder.include(include_path.data());
 
         // @note: @es3n1n: get stuff from schema that we'll use later

--- a/src/sdk/sdk.cpp
+++ b/src/sdk/sdk.cpp
@@ -70,16 +70,6 @@ namespace sdk {
                 builder.comment("Has Trivial Constructor");
             if ((class_info->m_class_flags & SCHEMA_CF1_HAS_TRIVIAL_DESTRUCTOR) != 0)
                 builder.comment("Has Trivial Destructor");
-            if ((class_info->m_class_flags & SCHEMA_CF1_HAS_NOSCHEMA_MEMBERS) != 0)
-                builder.comment("Has No Schema Members");
-            if ((class_info->m_class_flags & SCHEMA_CF1_IS_LOCAL_TYPE_SCOPE) != 0)
-                builder.comment("Is Local Type Scope");
-            if ((class_info->m_class_flags & SCHEMA_CF1_IS_GLOBAL_TYPE_SCOPE) != 0)
-                builder.comment("Is Global Type Scope");
-            if ((class_info->m_class_flags & SCHEMA_CF1_IS_NOSCHEMA_CLASS) != 0)
-                builder.comment("Not Schema Class");
-            if (class_info->m_has_base_class == 1)
-                builder.comment("Has Base Class");
 
             if (class_info->m_metadata_size > 0)
                 builder.comment("");

--- a/src/startup/entrypoint/dllmain.cpp
+++ b/src/startup/entrypoint/dllmain.cpp
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #include <Include.h>
 
 namespace {
@@ -27,3 +29,21 @@ BOOL APIENTRY DllMain(const HMODULE module, const DWORD reason, LPVOID reserved 
 
     return TRUE;
 }
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/src/startup/startup.cpp
+++ b/src/startup/startup.cpp
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
 #include <Include.h>
 #include <sdk/sdk.h>
 
@@ -95,3 +97,21 @@ namespace source2_gen {
         FreeLibraryAndExitThread(module, EXIT_SUCCESS);
     }
 } // namespace source2_gen
+
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+

--- a/src/startup/startup.cpp
+++ b/src/startup/startup.cpp
@@ -12,6 +12,7 @@ namespace {
         "client.dll"sv,
         "engine2.dll"sv,
         "schemasystem.dll"sv,
+        "tier0.dll"sv,
         
         // @note: @soufiw: latest modules that gets loaded in the main menu
         "navsystem.dll"sv,
@@ -61,11 +62,9 @@ namespace source2_gen {
         //
         sdk::GenerateTypeScopeSdk(sdk::g_schema->GlobalTypeScope());
 
-        static const auto pretiffy_num_fn = reinterpret_cast<const char*(*)(int)>(GetProcAddress(GetModuleHandleA("tier0.dll"), "V_PrettifyNum"));
-
         std::cout << std::format("Schema stats: {} registrations; {} were redundant; {} were ignored ({} bytes of ignored data)",
-                                 pretiffy_num_fn(sdk::g_schema->GetRegistration()), pretiffy_num_fn(sdk::g_schema->GetRedundant()),
-                                 pretiffy_num_fn(sdk::g_schema->GetIgnored()), pretiffy_num_fn(sdk::g_schema->GetIgnoredBytes()))
+                                 util::PrettifyNum(sdk::g_schema->GetRegistration()), util::PrettifyNum(sdk::g_schema->GetRedundant()),
+                                 util::PrettifyNum(sdk::g_schema->GetIgnored()), util::PrettifyNum(sdk::g_schema->GetIgnoredBytes()))
                   << std::endl;
 
         // @note: @es3n1n: We are done here

--- a/src/startup/startup.cpp
+++ b/src/startup/startup.cpp
@@ -48,6 +48,9 @@ namespace source2_gen {
         if (!sdk::g_schema)
             throw std::runtime_error(std::format("Unable to obtain Schema interface"));
 
+        while(!sdk::g_schema->SchemaSystemIsReady())
+            sleep_for(std::chrono::seconds(5));
+
         // @note: @es3n1n: Obtaining type scopes and generating sdk
         //
         const auto type_scopes = sdk::g_schema->GetTypeScopes();
@@ -57,6 +60,13 @@ namespace source2_gen {
         // @note: @es3n1n: Generating sdk for global type scope
         //
         sdk::GenerateTypeScopeSdk(sdk::g_schema->GlobalTypeScope());
+
+        static const auto pretiffy_num_fn = reinterpret_cast<const char*(*)(int)>(GetProcAddress(GetModuleHandleA("tier0.dll"), "V_PrettifyNum"));
+
+        std::cout << std::format("Schema stats: {} registrations; {} were redundant; {} were ignored ({} bytes of ignored data)",
+                                 pretiffy_num_fn(sdk::g_schema->GetRegistration()), pretiffy_num_fn(sdk::g_schema->GetRedundant()),
+                                 pretiffy_num_fn(sdk::g_schema->GetIgnored()), pretiffy_num_fn(sdk::g_schema->GetIgnoredBytes()))
+                  << std::endl;
 
         // @note: @es3n1n: We are done here
         //


### PR DESCRIPTION
1. Add Schema stats at end of dumping SDK
2. Netvars now have more static metadata described (e.g. MNetworkEncodeFlags, MNetworkEncoder)
3. Classes now does have static metadata describe
4. Classes now does have flags describe (e.g. Is polymorphic, is abstract and etc)
5. Enum class now does have static metadata describe
6. Enum values now does have static metadata describe
7. Fully rebuilt SchemaClassInfoData_t
8. Update SchemaClassFlags_t
9. Update SchemaEnumeratorInfoData_t
10. Add SchemaFieldMetadataOverrideData_t with SchemaFieldMetadataOverrideSetData_t
11. Add some functions to SchemaSystem
12. It seems that valve is doing its best as always to keep everything good and without bugs, so we need to fix std::uint8_t::max to 8 by default in align_of. GetAligment wrapper added to SchemaClassInfoData_t
13. Add util with PrettifyNum
14. Add wrappers std::vector<T> for fields, static fields, static metadata, static metadata overrides for CSchemaClassInfo
15. Add wrappers for GetPrevClassName, HasVirtualTable, RecursiveHasVirtualTable, IsInherits, IsRecusriveInherits, GetSize to CSchemaClassInfo
16.  CSchemaClassBinding and CSchemaEnumBinding is now aliases
17.  Add ValidateClasses to SchemaSystem and minor refactor
18. Add CSchemaEnumInfoData which basically class with wrappers
19. Minor changes in sdk gen (like missing const, using std::vector foreach instead of default for and etc
20. "No members available" change to "No schema binary for binding" since it how valve describes such classes
21. Add acknowledgement
22.  Remove unused SchemaString, SchemaArray
23. Add SchemaClassInfoFunctionIndex to SchemaClassInfoData_t and added wrappers for these functions.
24. Added CopyInstance, CreateInstance, CreateInstanceWithMemory, DestroyInstance, DestroyInstanceWithMemory, SchemaClassBinding to CSchemaClassBinding

Reverse Engineering Circus arrived with some ready to cook paste :clown: