### PR TITLE
Embedding non-pointer props

### DIFF
--- a/include/tools/codegen.h
+++ b/include/tools/codegen.h
@@ -322,6 +322,7 @@ namespace codegen {
     }
 } // namespace codegen
 
+
 // source2gen - Source2 games SDK generator
 // Copyright 2023 neverlosecc
 //

--- a/include/tools/codegen.h
+++ b/include/tools/codegen.h
@@ -59,11 +59,15 @@ namespace codegen {
         }
 
         self_ref disable_warnings(const std::string& codes) {
-            return push_line("#pragma warning(push)").push_line(std::format("#pragma warning(disable: {})", codes));
+            return push_warning().pragma(std::format("warning(disable: {})", codes));
+        }
+
+        self_ref push_warning() {
+            return pragma("warning(push)");
         }
 
         self_ref pop_warning() {
-            return push_line("#pragma warning(pop)");
+            return pragma("warning(pop)");
         }
 
         self_ref next_line() {
@@ -211,7 +215,7 @@ namespace codegen {
             return push_line(line, move_cursor_to_next_line);
         }
 
-        self_ref forward_declartion(const std::string& text) {
+        self_ref forward_declaration(const std::string& text) {
             // @note: @es3n1n: forward decl only once
             const auto fwd_decl_hash = fnv32::hash_runtime(text.data());
             if (_forward_decls.contains(fwd_decl_hash))
@@ -318,7 +322,6 @@ namespace codegen {
     }
 } // namespace codegen
 
-
 // source2gen - Source2 games SDK generator
 // Copyright 2023 neverlosecc
 //
@@ -334,4 +337,3 @@ namespace codegen {
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-

--- a/src/sdk/sdk.cpp
+++ b/src/sdk/sdk.cpp
@@ -11,6 +11,10 @@ namespace {
     constexpr std::string_view kOutDirName = "sdk"sv;
     constinit std::array include_paths = {"<cstdint>"sv, "\"!GlobalTypes.hpp\""sv};
 
+    constexpr uint32_t kMaxReferencesForClassEmbed = 2;
+    constexpr size_t kMinFieldCountForClassEmbed = 2;
+    constexpr size_t kMaxFieldCountForClassEmbed = 12;
+
     constinit std::array string_metadata_entries = {
         FNV32("MNetworkChangeCallback"),  FNV32("MPropertyFriendlyName"), FNV32("MPropertyDescription"),
         FNV32("MPropertyAttributeRange"), FNV32("MPropertyStartGroup"),   FNV32("MPropertyAttributeChoiceName"),
@@ -528,16 +532,17 @@ namespace sdk {
                         if (prop_class->cached_fields_.empty())
                             continue;
 
-                        if (prop_class->cached_fields_.size() < 2 || prop_class->cached_fields_.size() > 12)
+                        if (prop_class->cached_fields_.size() < kMinFieldCountForClassEmbed || 
+                            prop_class->cached_fields_.size() > kMaxFieldCountForClassEmbed)
                             continue;
 
                         // if a class is used in too many classes its likely not very useful + will bloat the dump, so ignore it
-                        if (prop_class->used_count_ > 2) 
+                        if (prop_class->used_count_ > kMaxReferencesForClassEmbed) 
                             continue;
 
                         for (const auto& [cached_field_name, cached_field_offset] : prop_class->cached_fields_) {
                             const auto accumulated_offset = cached_field_offset + field.m_single_inheritance_offset;
-                            builder.comment(std::format("-> {} - {:#x}", cached_field_name,accumulated_offset));
+                            builder.comment(std::format("-> {} - {:#x}", cached_field_name, accumulated_offset));
                         }
                     }
 


### PR DESCRIPTION
I went ahead and implemented my idea from https://github.com/neverlosecc/source2gen/issues/26

Ive opted to go with adding the offsets into the metadata of the prop for simplicity sake. Though i still had to make minor changes to the code structure in order to avoid bloat.

The conditions for whether a prop should be directly embedded are as follows
- Does it have more than 1 field and less than 13 fields (random numbers i just pulled out of my ass)
- Is it not used by more than 2 classes (some classes such as GameTime_t are used all over the place and in order to avoid bloating the dump with a bunch of embedded data i decided it'd be a good idea to only embed classes that arent frequently used)

With the changes applied a dump will now embed ~50 classes across all binaries and will look like this
```c++
// MNetworkEnable
// -> m_hModel - 0x200
// -> m_ModelName - 0x208
// -> m_bClientClothCreationSuppressed - 0x248
// -> m_MeshGroupMask - 0x2e0
// -> m_nIdealMotionType - 0x382
// -> m_nForceLOD - 0x383
// -> m_nClothUpdateFlags - 0x384
CModelState m_modelState; // 0x160	
```
