### PR TITLE
:circus_tent:

### DIFF
--- a/include/sdk/interfaces/client/game/datamap_t.h
+++ b/include/sdk/interfaces/client/game/datamap_t.h
@@ -1,0 +1,290 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
+#pragma once
+
+class ISaveRestoreOps;
+class typedescription_t;
+class IPredictionCopyOps;
+
+enum {
+    FTYPEDESC_NONE = 0
+};
+
+enum DatamapFlags : int
+{
+    // This field is masked for global entity save/restore
+    FTYPEDESC_GLOBAL = (1 << 0),
+    // This field is saved to disk
+    FTYPEDESC_SAVE = (1 << 1),
+    // This field can be requested and written to by string name at load time
+    FTYPEDESC_KEY = (1 << 2),
+    // This field can be written to by string name at run time, and a function called
+    FTYPEDESC_INPUT = (1 << 3),
+    // This field propogates it's value to all targets whenever it changes
+    FTYPEDESC_OUTPUT = (1 << 4),
+    // This is a table entry for a member function pointer
+    FTYPEDESC_FUNCTIONTABLE = (1 << 5),
+    // This field is a pointer, not an embedded object
+    FTYPEDESC_PTR = (1 << 6),
+    // The field is an override for one in a base class (only used by prediction system for now)
+    FTYPEDESC_OVERRIDE = (1 << 7),
+    // Flags used by other systems (e.g., prediction system)
+    FTYPEDESC_INSENDTABLE = (1 << 8),
+    // This field is present in a network SendTable
+    // The field is local to the client or server only (not referenced by prediction code and not replicated by
+    // networking
+    FTYPEDESC_PRIVATE = (1 << 9),
+    // The field is part of the prediction typedescription, but doesn't get compared when checking for errors
+    FTYPEDESC_NOERRORCHECK = (1 << 10),
+    // The field is a model index (used for debugging output)
+    FTYPEDESC_MODELINDEX = (1 << 11),
+    // The field is an index into file data, used for byteswapping.
+    FTYPEDESC_INDEX = (1 << 12),
+    FTYPEDESC_OVERRIDE_RECURSIVE = (1 << 13),
+    FTYPEDESC_SCHEMA_INITIALIZED = (1 << 14),
+    FTYPEDESC_GEN_ARRAY_KEYNAMES_0 = (1 << 15),
+    FTYPEDESC_GEN_ARRAY_KEYNAMES_1 = (1 << 16),
+    FTYPEDESC_ADDITIONAL_FIELDS = (1 << 17),
+    FTYPEDESC_EXPLICIT_BASE = (1 << 18),
+    FTYPEDESC_PROCEDURAL_KEYFIELD = (1 << 19),
+    // Used if the typedesc is enum, no datamap_t info would be available
+    FTYPEDESC_ENUM = (1 << 20),
+    FTYPEDESC_REMOVED_KEYFIELD = (1 << 21),
+    FTYPEDESC_WAS_INPUT = (1 << 22),
+    FTYPEDESC_WAS_OUTPUT = (1 << 23)
+};
+
+enum {
+    TD_OFFSET_NORMAL = 0,
+    TD_OFFSET_PACKED = 1,
+
+    // Must be last
+    TD_OFFSET_COUNT,
+};
+
+enum PredictionCopyType_t {
+    PC_NON_NETWORKED_ONLY = 0,
+    PC_NETWORKED_ONLY,
+
+    PC_COPYTYPE_COUNT,
+    PC_EVERYTHING = PC_COPYTYPE_COUNT,
+};
+
+// Registered binary: schemasystem.dll (project 'schemasystem')
+// Alignment: 1
+// Size: 0x50
+enum class fieldtype_t : uint8_t {
+    FIELD_VOID = 0x0,
+    FIELD_FLOAT32 = 0x1,
+    FIELD_STRING = 0x2,
+    FIELD_VECTOR = 0x3,
+    FIELD_QUATERNION = 0x4,
+    FIELD_INT32 = 0x5,
+    FIELD_BOOLEAN = 0x6,
+    FIELD_INT16 = 0x7,
+    FIELD_CHARACTER = 0x8,
+    FIELD_COLOR32 = 0x9,
+    FIELD_EMBEDDED = 0xa,
+    FIELD_CUSTOM = 0xb,
+    FIELD_CLASSPTR = 0xc,
+    FIELD_EHANDLE = 0xd,
+    FIELD_POSITION_VECTOR = 0xe,
+    FIELD_TIME = 0xf,
+    FIELD_TICK = 0x10,
+    FIELD_SOUNDNAME = 0x11,
+    FIELD_INPUT = 0x12,
+    FIELD_FUNCTION = 0x13,
+    FIELD_VMATRIX = 0x14,
+    FIELD_VMATRIX_WORLDSPACE = 0x15,
+    FIELD_MATRIX3X4_WORLDSPACE = 0x16,
+    FIELD_INTERVAL = 0x17,
+    FIELD_UNUSED = 0x18,
+    FIELD_VECTOR2D = 0x19,
+    FIELD_INT64 = 0x1a,
+    FIELD_VECTOR4D = 0x1b,
+    FIELD_RESOURCE = 0x1c,
+    FIELD_TYPEUNKNOWN = 0x1d,
+    FIELD_CSTRING = 0x1e,
+    FIELD_HSCRIPT = 0x1f,
+    FIELD_VARIANT = 0x20,
+    FIELD_UINT64 = 0x21,
+    FIELD_FLOAT64 = 0x22,
+    FIELD_POSITIVEINTEGER_OR_NULL = 0x23,
+    FIELD_HSCRIPT_NEW_INSTANCE = 0x24,
+    FIELD_UINT32 = 0x25,
+    FIELD_UTLSTRINGTOKEN = 0x26,
+    FIELD_QANGLE = 0x27,
+    FIELD_NETWORK_ORIGIN_CELL_QUANTIZED_VECTOR = 0x28,
+    FIELD_HMATERIAL = 0x29,
+    FIELD_HMODEL = 0x2a,
+    FIELD_NETWORK_QUANTIZED_VECTOR = 0x2b,
+    FIELD_NETWORK_QUANTIZED_FLOAT = 0x2c,
+    FIELD_DIRECTION_VECTOR_WORLDSPACE = 0x2d,
+    FIELD_QANGLE_WORLDSPACE = 0x2e,
+    FIELD_QUATERNION_WORLDSPACE = 0x2f,
+    FIELD_HSCRIPT_LIGHTBINDING = 0x30,
+    FIELD_V8_VALUE = 0x31,
+    FIELD_V8_OBJECT = 0x32,
+    FIELD_V8_ARRAY = 0x33,
+    FIELD_V8_CALLBACK_INFO = 0x34,
+    FIELD_UTLSTRING = 0x35,
+    FIELD_NETWORK_ORIGIN_CELL_QUANTIZED_POSITION_VECTOR = 0x36,
+    FIELD_HRENDERTEXTURE = 0x37,
+    FIELD_HPARTICLESYSTEMDEFINITION = 0x38,
+    FIELD_UINT8 = 0x39,
+    FIELD_UINT16 = 0x3a,
+    FIELD_CTRANSFORM = 0x3b,
+    FIELD_CTRANSFORM_WORLDSPACE = 0x3c,
+    FIELD_HPOSTPROCESSING = 0x3d,
+    FIELD_MATRIX3X4 = 0x3e,
+    FIELD_SHIM = 0x3f,
+    FIELD_CMOTIONTRANSFORM = 0x40,
+    FIELD_CMOTIONTRANSFORM_WORLDSPACE = 0x41,
+    FIELD_ATTACHMENT_HANDLE = 0x42,
+    FIELD_AMMO_INDEX = 0x43,
+    FIELD_CONDITION_ID = 0x44,
+    FIELD_AI_SCHEDULE_BITS = 0x45,
+    FIELD_MODIFIER_HANDLE = 0x46,
+    FIELD_ROTATION_VECTOR = 0x47,
+    FIELD_ROTATION_VECTOR_WORLDSPACE = 0x48,
+    FIELD_HVDATA = 0x49,
+    FIELD_SCALE32 = 0x4a,
+    FIELD_STRING_AND_TOKEN = 0x4b,
+    FIELD_ENGINE_TIME = 0x4c,
+    FIELD_ENGINE_TICK = 0x4d,
+    FIELD_WORLD_GROUP_ID = 0x4e,
+    FIELD_TYPECOUNT = 0x4f,
+};
+
+// Each datamap_t is broken down into two flattened arrays of fields,
+//  one for PC_NETWORKED_DATA and one for PC_NON_NETWORKED_ONLY (optimized_datamap_t::datamapinfo_t::flattenedoffsets_t)
+// Each flattened array is sorted by offset for better cache performance
+// Finally, contiguous "runs" off offsets are precomputed (optimized_datamap_t::datamapinfo_t::datacopyruns_t) for fast
+// copy operations
+
+// A data run is a set of DEFINE_PRED_FIELD fields in a c++ object which are contiguous and can be processing
+//  using a single memcpy operation
+struct datarun_t {
+    datarun_t(): m_nStartFlatField(0), m_nEndFlatField(0), m_nLength(0) {
+        for (int i = 0; i < TD_OFFSET_COUNT; ++i) {
+            m_nStartOffset[i] = 0;
+#ifdef _X360
+            // These are the offsets of the next run, for priming the L1 cache
+            m_nPrefetchOffset[i] = 0;
+#endif
+        }
+    }
+
+    // Indices of start/end fields in the flattened typedescription_t list
+    int m_nStartFlatField;
+    int m_nEndFlatField;
+
+    // Offsets for run in the packed/unpacked data (I think the run starts need to be properly aligned)
+    int m_nStartOffset[TD_OFFSET_COUNT];
+#ifdef _X360
+    // These are the offsets of the next run, for priming the L1 cache
+    int m_nPrefetchOffset[TD_OFFSET_COUNT];
+#endif
+    int m_nLength;
+};
+
+struct datacopyruns_t {
+public:
+    CUtlVector<datarun_t> m_vecRuns;
+};
+
+struct flattenedoffsets_t {
+    CUtlVector<typedescription_t> m_Flattened;
+    int m_nPackedSize; // Contiguous memory to pack all of these together for TD_OFFSET_PACKED
+    int m_nPackedStartOffset;
+};
+
+struct datamapinfo_t {
+    // Flattened list, with FIELD_EMBEDDED, FTYPEDESC_PRIVATE,
+    //  and FTYPEDESC_OVERRIDE (overridden) fields removed
+    flattenedoffsets_t m_Flat;
+    datacopyruns_t m_CopyRuns;
+};
+
+struct optimized_datamap_t {
+    // Optimized info for PC_NON_NETWORKED and PC_NETWORKED data
+    datamapinfo_t m_Info[PC_COPYTYPE_COUNT];
+};
+
+class datamap_t {
+public:
+    typedescription_t* m_pTypeDescription;
+    std::uint64_t m_iTypeDescriptionCount;
+    const char* m_pszClassName; // Ex: C_DOTAPlayer
+    datamap_t* m_pBaseDatamap; // Ex: For C_DOTAPlayer it would be next baseclass C_BasePlayer, can be NULL
+    int m_nPackedSize;
+    optimized_datamap_t* m_pOptimizedDataMap;
+};
+
+class typedescription_t {
+public:
+    std::string_view GetFieldName() {
+        if (m_pszFieldName)
+            return {m_pszFieldName};
+
+        return {};
+    }
+
+    std::string_view GetExternalFieldName() {
+        if (m_pszExternalName)
+            return {m_pszExternalName};
+
+        return {};
+    }
+
+public:
+    fieldtype_t m_iFieldType;
+    const char* m_pszFieldName;
+    int m_iOffset; // Local offset value
+    std::uint16_t m_nFieldSize;
+    DatamapFlags m_nFlags;
+    // the name of the variable in the map/fgd data, or the name of the action
+    const char* m_pszExternalName;
+    // pointer to the function set for save/restoring of custom data types
+    ISaveRestoreOps* m_pSaveRestoreOps;
+    // for associating function with string names
+    void* m_pInputFn;
+
+    // For embedding additional datatables inside this one
+    union {
+        datamap_t* m_pDataMap;
+        const char* m_pszEnumName;
+    };
+
+    // Stores the actual member variable size in bytes
+    int m_iFieldSizeInBytes;
+
+    // Tolerance for field errors for float fields
+    float m_flFieldTolerance;
+
+    // For raw fields (including children of embedded stuff) this is the flattened offset
+    int m_flFlatOffset[TD_OFFSET_COUNT];
+    std::uint16_t m_uFlatGroup;
+
+    IPredictionCopyOps* pPredictionCopyOps;
+    datamap_t* m_pPredictionCopyDataMap;
+
+    ~typedescription_t();
+};
+static_assert(sizeof(typedescription_t) == 0x68);
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -13,7 +13,7 @@
 #include <SDK/Interfaces/common/CUtlTSHash.h>
 #include <tools/virtual.h>
 
-#define CSGO2
+#define CS2
 
 #ifdef SBOX
 // untested, CSchemaType::m_schema_type_ might be wrong
@@ -53,7 +53,7 @@
     #error "unimplemented"
 #elif defined THE_LAB_ROBOT_REPAIR
     #error "unimplemented"
-#elif defined(CSGO2) || defined(DOTA2)
+#elif defined(CS2) || defined(DOTA2)
     #define CSCHEMATYPE_GETSIZES_INDEX 3
     #define CSCHEMASYSTEM_VALIDATECLASSES 35
     #define SCHEMASYSTEM_TYPE_SCOPES_OFFSET 0x190
@@ -87,12 +87,11 @@ enum SchemaClassFlags_t {
     SCHEMA_CF1_IS_LOCAL_TYPE_SCOPE = 64,
     SCHEMA_CF1_IS_GLOBAL_TYPE_SCOPE = 128,
 
-#if defined(CSGO2) || defined(DOTA2)
+#if defined(CS2) || defined(DOTA2)
     SCHEMA_CF1_IS_SCHEMA_VALIDATED = 2048,
 #else
     SCHEMA_CF1_IS_SCHEMA_VALIDATED = 1024,
 #endif
-
 };
 
 enum ETypeCategory {
@@ -113,92 +112,6 @@ enum EAtomicCategory {
     Atomic_TT,
     Atomic_I,
     Atomic_None
-};
-
-// Registered binary: schemasystem.dll (project 'schemasystem')
-// Alignment: 1
-// Size: 0x50
-enum class fieldtype_t : uint8_t {
-    FIELD_VOID = 0x0,
-    FIELD_FLOAT32 = 0x1,
-    FIELD_STRING = 0x2,
-    FIELD_VECTOR = 0x3,
-    FIELD_QUATERNION = 0x4,
-    FIELD_INT32 = 0x5,
-    FIELD_BOOLEAN = 0x6,
-    FIELD_INT16 = 0x7,
-    FIELD_CHARACTER = 0x8,
-    FIELD_COLOR32 = 0x9,
-    FIELD_EMBEDDED = 0xa,
-    FIELD_CUSTOM = 0xb,
-    FIELD_CLASSPTR = 0xc,
-    FIELD_EHANDLE = 0xd,
-    FIELD_POSITION_VECTOR = 0xe,
-    FIELD_TIME = 0xf,
-    FIELD_TICK = 0x10,
-    FIELD_SOUNDNAME = 0x11,
-    FIELD_INPUT = 0x12,
-    FIELD_FUNCTION = 0x13,
-    FIELD_VMATRIX = 0x14,
-    FIELD_VMATRIX_WORLDSPACE = 0x15,
-    FIELD_MATRIX3X4_WORLDSPACE = 0x16,
-    FIELD_INTERVAL = 0x17,
-    FIELD_UNUSED = 0x18,
-    FIELD_VECTOR2D = 0x19,
-    FIELD_INT64 = 0x1a,
-    FIELD_VECTOR4D = 0x1b,
-    FIELD_RESOURCE = 0x1c,
-    FIELD_TYPEUNKNOWN = 0x1d,
-    FIELD_CSTRING = 0x1e,
-    FIELD_HSCRIPT = 0x1f,
-    FIELD_VARIANT = 0x20,
-    FIELD_UINT64 = 0x21,
-    FIELD_FLOAT64 = 0x22,
-    FIELD_POSITIVEINTEGER_OR_NULL = 0x23,
-    FIELD_HSCRIPT_NEW_INSTANCE = 0x24,
-    FIELD_UINT32 = 0x25,
-    FIELD_UTLSTRINGTOKEN = 0x26,
-    FIELD_QANGLE = 0x27,
-    FIELD_NETWORK_ORIGIN_CELL_QUANTIZED_VECTOR = 0x28,
-    FIELD_HMATERIAL = 0x29,
-    FIELD_HMODEL = 0x2a,
-    FIELD_NETWORK_QUANTIZED_VECTOR = 0x2b,
-    FIELD_NETWORK_QUANTIZED_FLOAT = 0x2c,
-    FIELD_DIRECTION_VECTOR_WORLDSPACE = 0x2d,
-    FIELD_QANGLE_WORLDSPACE = 0x2e,
-    FIELD_QUATERNION_WORLDSPACE = 0x2f,
-    FIELD_HSCRIPT_LIGHTBINDING = 0x30,
-    FIELD_V8_VALUE = 0x31,
-    FIELD_V8_OBJECT = 0x32,
-    FIELD_V8_ARRAY = 0x33,
-    FIELD_V8_CALLBACK_INFO = 0x34,
-    FIELD_UTLSTRING = 0x35,
-    FIELD_NETWORK_ORIGIN_CELL_QUANTIZED_POSITION_VECTOR = 0x36,
-    FIELD_HRENDERTEXTURE = 0x37,
-    FIELD_HPARTICLESYSTEMDEFINITION = 0x38,
-    FIELD_UINT8 = 0x39,
-    FIELD_UINT16 = 0x3a,
-    FIELD_CTRANSFORM = 0x3b,
-    FIELD_CTRANSFORM_WORLDSPACE = 0x3c,
-    FIELD_HPOSTPROCESSING = 0x3d,
-    FIELD_MATRIX3X4 = 0x3e,
-    FIELD_SHIM = 0x3f,
-    FIELD_CMOTIONTRANSFORM = 0x40,
-    FIELD_CMOTIONTRANSFORM_WORLDSPACE = 0x41,
-    FIELD_ATTACHMENT_HANDLE = 0x42,
-    FIELD_AMMO_INDEX = 0x43,
-    FIELD_CONDITION_ID = 0x44,
-    FIELD_AI_SCHEDULE_BITS = 0x45,
-    FIELD_MODIFIER_HANDLE = 0x46,
-    FIELD_ROTATION_VECTOR = 0x47,
-    FIELD_ROTATION_VECTOR_WORLDSPACE = 0x48,
-    FIELD_HVDATA = 0x49,
-    FIELD_SCALE32 = 0x4a,
-    FIELD_STRING_AND_TOKEN = 0x4b,
-    FIELD_ENGINE_TIME = 0x4c,
-    FIELD_ENGINE_TICK = 0x4d,
-    FIELD_WORLD_GROUP_ID = 0x4e,
-    FIELD_TYPECOUNT = 0x4f,
 };
 
 struct CSchemaVarName {
@@ -337,23 +250,8 @@ struct SchemaClassFieldData_t {
     SchemaMetadataEntryData_t* m_metadata; // 0x0018
 };
 
-struct SchemaFieldMetadataOverrideData_t {
-    fieldtype_t m_field_type; // 0x0000
-    char pad_0001[7]; // 0x0001
-    const char* m_field_name; // 0x0008
-    std::uint32_t m_single_inheritance_offset; // 0x0010
-    std::int32_t m_field_count; // 0x0014 // @note: @og: if its array or smth like this it will point to count of array
-    std::int32_t m_i_unk_1; // 0x0018
-    char pad_001C[12]; // 0x001C
-    ISaveRestoreOps* m_def_save_restore_ops; // 0x0028
-    char pad_0030[16]; // 0x0030
-    std::uint32_t m_align; // 0x0040
-    char pad_0044[36]; // 0x0044
-}; // Size: 0x0068
-static_assert(sizeof(SchemaFieldMetadataOverrideData_t) == 0x68);
-
 struct SchemaStaticFieldData_t {
-    const char* name; // 0x0000
+    const char* m_name; // 0x0000
     CSchemaType* m_type; // 0x0008
     void* m_instance; // 0x0010
     char pad_0x0018[0x10]; // 0x0018
@@ -364,10 +262,8 @@ struct SchemaBaseClassInfoData_t {
     CSchemaClassInfo* m_prev_by_class; // 0x0008
 };
 
-struct SchemaFieldMetadataOverrideSetData_t {
-    SchemaFieldMetadataOverrideData_t* m_metadata_override_data; // 0x0008
-    std::int32_t m_size; // 0x0008
-};
+using SchemaFieldMetadataOverrideSetData_t = datamap_t;
+using SchemaFieldMetadataOverrideData_t = typedescription_t;
 
 struct SchemaClassInfoData_t {
 public:
@@ -375,13 +271,12 @@ public:
         kRegisterClassSchema = 0,
         kUnknown = 1, // @note: @og: Can't find fn with such index
         kCopyInstance = 2,
-        kCreateInstance = 3, 
+        kCreateInstance = 3,
         kDestroyInstance = 4,
         kCreateInstanceWithMemory = 5,
         kDestroyInstanceWithMemory = 6,
         kSchemaDynamicBinding = 7
     };
-
 public:
     SchemaClassInfoData_t* m_self; // 0x0000
     const char* m_name; // 0x0008
@@ -401,7 +296,7 @@ public:
     SchemaMetadataEntryData_t* m_static_metadata; // 0x0048
     CSchemaSystemTypeScope* m_type_scope; // 0x0050
     CSchemaType* m_schema_type; // 0x0058
-    SchemaClassFlags_t m_class_flags : 8; // 0x0060
+    SchemaClassFlags_t m_class_flags:8; // 0x0060
     std::uint32_t m_sequence; // 0x0064 // @note: @og: idk
     void* m_fn; // 0x0068
 };
@@ -438,13 +333,13 @@ public:
         return {m_static_metadata, m_static_metadata + m_static_metadata_size};
     }
 
-    std::vector<SchemaFieldMetadataOverrideData_t> GetStaticFieldMetadataOverrides() const {
+    /*std::vector<SchemaFieldMetadataOverrideData_t*> GetStaticFieldMetadataOverrides() const {
         if (!m_field_metadata_overrides)
             return {};
 
-        return {m_field_metadata_overrides->m_metadata_override_data,
-                m_field_metadata_overrides->m_metadata_override_data + m_field_metadata_overrides->m_size};
-    }
+        return {m_field_metadata_overrides->m_iTypeDescriptionCount,
+                m_field_metadata_overrides->m_pTypeDescription + m_field_metadata_overrides->m_iTypeDescriptionCount};
+    }*/
 
     [[nodiscard]] std::string_view GetPrevClassName() const {
         if (!m_base_classes || !m_base_classes->m_prev_by_class)
@@ -487,13 +382,15 @@ public:
         return reinterpret_cast<Fn>(m_fn)(SchemaClassInfoFunctionIndex::kCreateInstance, instance, new_instance);
     }
 
-    // @note: @og: Creates default instance with engine allocated memory (e.g. if SchemaClassInfoData_t is C_BaseEntity, then Instance will be C_BaseEntity)
+    // @note: @og: Creates default instance with engine allocated memory (e.g. if SchemaClassInfoData_t is C_BaseEntity, then Instance will be
+    // C_BaseEntity)
     void* CreateInstance() const {
-        using Fn = void*(*)(SchemaClassInfoFunctionIndex);
+        using Fn = void* (*)(SchemaClassInfoFunctionIndex);
         return reinterpret_cast<Fn>(m_fn)(SchemaClassInfoFunctionIndex::kCreateInstance);
     }
 
-    // @note: @og: Creates default instance with your own allocated memory (e.g. if SchemaClassInfoData_t is C_BaseEntity, then Instance will be C_BaseEntity)
+    // @note: @og: Creates default instance with your own allocated memory (e.g. if SchemaClassInfoData_t is C_BaseEntity, then Instance will be
+    // C_BaseEntity)
     void* CreateInstance(void* memory) const {
         using Fn = void* (*)(SchemaClassInfoFunctionIndex, void*);
         return reinterpret_cast<Fn>(m_fn)(SchemaClassInfoFunctionIndex::kCreateInstanceWithMemory, memory);
@@ -580,7 +477,6 @@ private:
      * \brief (class_info->m_class_flags & 64) != 0;
      */
     using SchemaTypeScope_t = std::int32_t;
-
 public:
     CSchemaSystemTypeScope* GlobalTypeScope(void) {
         return Virtual::Get<CSchemaSystemTypeScope*(__thiscall*)(void*)>(this, 11)(this);
@@ -625,19 +521,18 @@ public:
     [[nodiscard]] std::int32_t GetRegistration() const {
         return m_registrations_;
     }
-    
+
     [[nodiscard]] std::int32_t GetIgnored() const {
         return m_ignored_;
     }
-    
+
     [[nodiscard]] std::int32_t GetRedundant() const {
         return m_redundant_;
     }
-    
+
     [[nodiscard]] std::int32_t GetIgnoredBytes() const {
         return m_ignored_bytes_;
     }
-
 private:
     char pad_0x0000[SCHEMASYSTEM_TYPE_SCOPES_OFFSET]; // 0x0000
     CUtlVector<CSchemaSystemTypeScope*> m_type_scopes_ = {}; // SCHEMASYSTEM_TYPE_SCOPES_OFFSET
@@ -647,13 +542,11 @@ private:
     std::int32_t m_redundant_ = 0; // 0x02C8
     char pad_02CC[4] = {}; // 0x02CC
     std::int32_t m_ignored_bytes_ = 0; // 0x02D0
-
 public:
     static CSchemaSystem* GetInstance(void) {
         return sdk::GetInterface<CSchemaSystem>("schemasystem.dll", "SchemaSystem_0");
     }
 };
-
 
 // source2gen - Source2 games SDK generator
 // Copyright 2023 neverlosecc
@@ -670,4 +563,3 @@ public:
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-

--- a/include/sdk/interfaces/schemasystem/schema.h
+++ b/include/sdk/interfaces/schemasystem/schema.h
@@ -333,14 +333,6 @@ public:
         return {m_static_metadata, m_static_metadata + m_static_metadata_size};
     }
 
-    /*std::vector<SchemaFieldMetadataOverrideData_t*> GetStaticFieldMetadataOverrides() const {
-        if (!m_field_metadata_overrides)
-            return {};
-
-        return {m_field_metadata_overrides->m_iTypeDescriptionCount,
-                m_field_metadata_overrides->m_pTypeDescription + m_field_metadata_overrides->m_iTypeDescriptionCount};
-    }*/
-
     [[nodiscard]] std::string_view GetPrevClassName() const {
         if (!m_base_classes || !m_base_classes->m_prev_by_class)
             return {};

--- a/include/sdk/sdk.h
+++ b/include/sdk/sdk.h
@@ -13,6 +13,7 @@
 #include <sdk/interfaces/common/CUtlTSHash.h>
 
 #include <sdk/interfaceregs.h>
+#include <sdk/interfaces/client/game/datamap_t.h>
 #include <sdk/interfaces/schemasystem/Schema.h>
 
 namespace sdk {

--- a/include/tools/field_parser.h
+++ b/include/tools/field_parser.h
@@ -1,16 +1,17 @@
 // Copyright (C) 2023 neverlosecc
 // See end of file for extended copyright information.
+#pragma once
+
 #include <cstdint>
 #include <string>
 
-#include "codegen.h"
+enum class fieldtype_t : uint8_t;
 
 namespace field_parser {
-    struct field_info_t {
-        constexpr field_info_t() = default;
-        constexpr ~field_info_t() = default;
+    class field_info_t {
     public:
         std::string m_type = ""; // var type
+        fieldtype_t m_field_type = static_cast<fieldtype_t>(24); // var type
         std::string m_name = ""; // var name
 
         // array sizes, for example {13, 37} for multi demensional array "[13][37]"
@@ -61,94 +62,8 @@ namespace field_parser {
         }
     };
 
-    namespace detail {
-        namespace {
-            using namespace std::string_view_literals;
-
-            constexpr std::string_view kBitfieldTypePrefix = "bitfield:"sv;
-
-            constexpr std::string_view kArraySizePrefix = "["sv;
-            constexpr std::string_view kArraySizePostfix = "]"sv;
-
-            // clang-format off
-            constexpr std::initializer_list<std::pair<std::string_view, std::string_view>> kTypeNameToCpp = {
-                {"float32"sv, "float"sv}, 
-                {"float64"sv, "double"sv},
-    
-                {"int8"sv, "int8_t"sv},   
-                {"int16"sv, "int16_t"sv},   
-                {"int32"sv, "int32_t"sv},   
-                {"int64"sv, "int64_t"sv},
-    
-                {"uint8"sv, "uint8_t"sv}, 
-                {"uint16"sv, "uint16_t"sv}, 
-                {"uint32"sv, "uint32_t"sv}, 
-                {"uint64"sv, "uint64_t"sv}
-            };
-            // clang-format on
-        } // namespace
-
-        // @note: @es3n1n: basically the same thing as std::atoi
-        // but an exception would be thrown if we are unable to parse the string
-        //
-        __forceinline int wrapped_atoi(const char* s) {
-            const int result = std::atoi(s);
-
-            if (result == 0 && s && s[0] != '0')
-                throw std::runtime_error(std::format("{} : Unable to parse '{}'", __FUNCTION__, s));
-
-            return result;
-        }
-
-        __forceinline void parse_bitfield(field_info_t& result, const std::string& type_name) {
-            // @note: @es3n1n: in source2 schema, every bitfield var name would start with the "bitfield:" prefix
-            // so if there's no such prefix we would just skip the bitfield parsing.
-            if (type_name.size() < kBitfieldTypePrefix.size())
-                return;
-
-            if (const auto s = type_name.substr(0, kBitfieldTypePrefix.size()); s != kBitfieldTypePrefix.data())
-                return;
-
-            // @note: @es3n1n: type_name starts with the "bitfield:" prefix,
-            // now we can parse the bitfield size
-            const auto bitfield_size_str = type_name.substr(kBitfieldTypePrefix.size(), type_name.size() - kBitfieldTypePrefix.size());
-            const auto bitfield_size = wrapped_atoi(bitfield_size_str.data());
-
-            // @note: @es3n1n: saving parsed value
-            result.m_bitfield_size = bitfield_size;
-            result.m_type = codegen::guess_bitfield_type(bitfield_size);
-        }
-
-        // @note: @es3n1n: we are assuming that this function would be executed right after
-        // the bitfield/array parsing and the type would be already set if item is a bitfield
-        // or array
-        //
-        __forceinline void parse_type(field_info_t& result, const std::string& type_name) {
-            if (result.m_type.empty())
-                result.m_type = type_name;
-
-            // @note: @es3n1n: applying kTypeNameToCpp rules
-            for (auto& rule : kTypeNameToCpp) {
-                if (result.m_type != rule.first)
-                    continue;
-
-                result.m_type = rule.second;
-                break;
-            }
-        }
-    } // namespace detail
-
-    inline field_info_t parse(const std::string& type_name, const std::string& name, const std::vector<std::size_t>& array_sizes) {
-        field_info_t result = {};
-        result.m_name = name;
-
-        std::copy(array_sizes.begin(), array_sizes.end(), std::back_inserter(result.m_array_sizes));
-
-        detail::parse_bitfield(result, type_name);
-        detail::parse_type(result, type_name);
-
-        return result;
-    }
+    field_info_t parse(const std::string& type_name, const std::string& name, const std::vector<std::size_t>& array_sizes);
+    field_info_t parse(const fieldtype_t& type_name, const std::string& name, const std::size_t& array_sizes = 1);
 } // namespace field_parser
 
 

--- a/src/startup/startup.cpp
+++ b/src/startup/startup.cpp
@@ -18,7 +18,7 @@ namespace {
         
         // @note: @soufiw: latest modules that gets loaded in the main menu
         "navsystem.dll"sv,
-        #if defined(CSGO2)
+        #if defined(CS2)
         "matchmaking.dll"sv,
         #endif
     };

--- a/src/tools/field_parser.cpp
+++ b/src/tools/field_parser.cpp
@@ -1,0 +1,178 @@
+// Copyright (C) 2023 neverlosecc
+// See end of file for extended copyright information.
+#include <Include.h>
+
+namespace field_parser {
+    namespace detail {
+        namespace {
+            using namespace std::string_view_literals;
+
+            constexpr std::string_view kBitfieldTypePrefix = "bitfield:"sv;
+
+            constexpr std::string_view kArraySizePrefix = "["sv;
+            constexpr std::string_view kArraySizePostfix = "]"sv;
+
+            // clang-format off
+            constexpr std::initializer_list<std::pair<std::string_view, std::string_view>> kTypeNameToCpp = {
+                {"float32"sv, "float"sv}, 
+                {"float64"sv, "double"sv},
+    
+                {"int8"sv, "int8_t"sv},   
+                {"int16"sv, "int16_t"sv},   
+                {"int32"sv, "int32_t"sv},   
+                {"int64"sv, "int64_t"sv},
+    
+                {"uint8"sv, "uint8_t"sv}, 
+                {"uint16"sv, "uint16_t"sv}, 
+                {"uint32"sv, "uint32_t"sv}, 
+                {"uint64"sv, "uint64_t"sv}
+            };
+
+            constexpr std::initializer_list<std::pair<fieldtype_t, std::string_view>> kDatamapToCpp = {
+                        {fieldtype_t::FIELD_FLOAT32, "float"sv},
+                        {fieldtype_t::FIELD_TIME, "GameTime_t"sv},
+                        {fieldtype_t::FIELD_ENGINE_TIME, "float"sv},
+                        {fieldtype_t::FIELD_FLOAT64, "double"sv},
+                        {fieldtype_t::FIELD_INT16, "int16_t"sv},
+                        {fieldtype_t::FIELD_INT32, "int32_t"sv},
+                        {fieldtype_t::FIELD_INT64, "int64_t"sv},
+                        {fieldtype_t::FIELD_UINT8, "uint8_t"sv},
+                        {fieldtype_t::FIELD_UINT16, "uint16_t"sv},
+                        {fieldtype_t::FIELD_UINT32, "uint32_t"sv},
+                        {fieldtype_t::FIELD_UINT64, "uint64_t"sv},
+                        {fieldtype_t::FIELD_BOOLEAN, "bool"sv},
+                        {fieldtype_t::FIELD_CHARACTER, "char"sv},
+                        {fieldtype_t::FIELD_VOID, "void"sv},
+                        {fieldtype_t::FIELD_STRING, "CUtlSymbolLarge"sv},
+                        {fieldtype_t::FIELD_VECTOR, "Vector"sv},
+                        {fieldtype_t::FIELD_POSITION_VECTOR, "Vector"sv},
+                        {fieldtype_t::FIELD_NETWORK_ORIGIN_CELL_QUANTIZED_VECTOR, "Vector"sv},
+                        {fieldtype_t::FIELD_DIRECTION_VECTOR_WORLDSPACE, "Vector"sv},
+                        {fieldtype_t::FIELD_NETWORK_QUANTIZED_VECTOR, "Vector"sv},
+                        {fieldtype_t::FIELD_VECTOR2D, "Vector2D"sv},
+                        {fieldtype_t::FIELD_VECTOR4D, "Vector4D"sv},
+                        {fieldtype_t::FIELD_QANGLE, "QAngle"sv},
+                        {fieldtype_t::FIELD_QANGLE_WORLDSPACE, "QAngle"sv},
+                        {fieldtype_t::FIELD_QUATERNION, "Quaternion"sv},
+                        {fieldtype_t::FIELD_CSTRING, "const char *"sv},
+                        {fieldtype_t::FIELD_UTLSTRING, "CUtlString"sv},
+                        {fieldtype_t::FIELD_UTLSTRINGTOKEN, "CUtlStringToken"sv},
+                        {fieldtype_t::FIELD_COLOR32, "Color"sv},
+                        {fieldtype_t::FIELD_WORLD_GROUP_ID, "WorldGroupId_t"sv},
+                        {fieldtype_t::FIELD_ROTATION_VECTOR, "RotationVector"sv},
+                        {fieldtype_t::FIELD_CTRANSFORM_WORLDSPACE, "CTransform"sv},
+                        {fieldtype_t::FIELD_EHANDLE, "CHandle< CBaseEntity >"sv},
+                        {fieldtype_t::FIELD_CUSTOM, "void"sv},
+                        {fieldtype_t::FIELD_HMODEL, "CStrongHandle< InfoForResourceTypeCModel >"sv},
+                        {fieldtype_t::FIELD_HMATERIAL, "CStrongHandle< InfoForResourceTypeIMaterial2 >"sv},
+                        {fieldtype_t::FIELD_SHIM, "SHIM"sv},
+                        {fieldtype_t::FIELD_FUNCTION, "void*"sv},
+                    };
+            // clang-format on
+        } // namespace
+
+        // @note: @es3n1n: basically the same thing as std::atoi
+        // but an exception would be thrown if we are unable to parse the string
+        //
+        int wrapped_atoi(const char* s) {
+            const int result = std::atoi(s);
+
+            if (result == 0 && s && s[0] != '0')
+                throw std::runtime_error(std::format("{} : Unable to parse '{}'", __FUNCTION__, s));
+
+            return result;
+        }
+
+        void parse_bitfield(field_info_t& result, const std::string& type_name) {
+            // @note: @es3n1n: in source2 schema, every bitfield var name would start with the "bitfield:" prefix
+            // so if there's no such prefix we would just skip the bitfield parsing.
+            if (type_name.size() < kBitfieldTypePrefix.size())
+                return;
+
+            if (const auto s = type_name.substr(0, kBitfieldTypePrefix.size()); s != kBitfieldTypePrefix.data())
+                return;
+
+            // @note: @es3n1n: type_name starts with the "bitfield:" prefix,
+            // now we can parse the bitfield size
+            const auto bitfield_size_str = type_name.substr(kBitfieldTypePrefix.size(), type_name.size() - kBitfieldTypePrefix.size());
+            const auto bitfield_size = wrapped_atoi(bitfield_size_str.data());
+
+            // @note: @es3n1n: saving parsed value
+            result.m_bitfield_size = bitfield_size;
+            result.m_type = codegen::guess_bitfield_type(bitfield_size);
+        }
+
+        // @note: @es3n1n: we are assuming that this function would be executed right after
+        // the bitfield/array parsing and the type would be already set if item is a bitfield
+        // or array
+        //
+        void parse_type(field_info_t& result, const std::string& type_name) {
+            if (result.m_type.empty())
+                result.m_type = type_name;
+
+            // @note: @es3n1n: applying kTypeNameToCpp rules
+            for (auto& rule : kTypeNameToCpp) {
+                if (result.m_type != rule.first)
+                    continue;
+
+                result.m_type = rule.second;
+                break;
+            }
+        }
+
+        // @note: @og: as above just modified for datamaps
+        void parse_type(field_info_t& result, const fieldtype_t& type_name) {
+            if (result.m_field_type == fieldtype_t::FIELD_UNUSED)
+                result.m_field_type = type_name;
+
+            // @note: @es3n1n: applying kTypeNameToCpp rules
+            for (auto& rule : kDatamapToCpp) {
+                if (result.m_field_type != rule.first)
+                    continue;
+
+                result.m_type = rule.second;
+                break;
+            }
+        }
+    } // namespace detail
+
+    field_info_t parse(const std::string& type_name, const std::string& name, const std::vector<std::size_t>& array_sizes) {
+        field_info_t result = {};
+        result.m_name = name;
+
+        std::copy(array_sizes.begin(), array_sizes.end(), std::back_inserter(result.m_array_sizes));
+
+        detail::parse_bitfield(result, type_name);
+        detail::parse_type(result, type_name);
+
+        return result;
+    }
+
+    field_info_t parse(const fieldtype_t& type_name, const std::string& name, const std::size_t& array_sizes) {
+        field_info_t result = {};
+        result.m_name = name;
+
+        if (array_sizes > 1)
+            result.m_array_sizes.emplace_back(array_sizes);
+
+        detail::parse_type(result, type_name);
+
+        return result;
+    }
+} // namespace field_parser
+
+// source2gen - Source2 games SDK generator
+// Copyright 2023 neverlosecc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//

--- a/src/tools/field_parser.cpp
+++ b/src/tools/field_parser.cpp
@@ -9,11 +9,8 @@ namespace field_parser {
 
             constexpr std::string_view kBitfieldTypePrefix = "bitfield:"sv;
 
-            constexpr std::string_view kArraySizePrefix = "["sv;
-            constexpr std::string_view kArraySizePostfix = "]"sv;
-
             // clang-format off
-            constexpr std::initializer_list<std::pair<std::string_view, std::string_view>> kTypeNameToCpp = {
+            constexpr std::array<std::pair<std::string_view, std::string_view>, 10> kTypeNameToCpp = {{
                 {"float32"sv, "float"sv}, 
                 {"float64"sv, "double"sv},
     
@@ -26,9 +23,9 @@ namespace field_parser {
                 {"uint16"sv, "uint16_t"sv}, 
                 {"uint32"sv, "uint32_t"sv}, 
                 {"uint64"sv, "uint64_t"sv}
-            };
+            }};
 
-            constexpr std::initializer_list<std::pair<fieldtype_t, std::string_view>> kDatamapToCpp = {
+            constexpr std::array<std::pair<fieldtype_t, std::string_view>, 38> kDatamapToCpp = {{
                         {fieldtype_t::FIELD_FLOAT32, "float"sv},
                         {fieldtype_t::FIELD_TIME, "GameTime_t"sv},
                         {fieldtype_t::FIELD_ENGINE_TIME, "float"sv},
@@ -67,7 +64,7 @@ namespace field_parser {
                         {fieldtype_t::FIELD_HMATERIAL, "CStrongHandle< InfoForResourceTypeIMaterial2 >"sv},
                         {fieldtype_t::FIELD_SHIM, "SHIM"sv},
                         {fieldtype_t::FIELD_FUNCTION, "void*"sv},
-                    };
+                    }};
             // clang-format on
         } // namespace
 

--- a/src/tools/field_parser.cpp
+++ b/src/tools/field_parser.cpp
@@ -10,7 +10,7 @@ namespace field_parser {
             constexpr std::string_view kBitfieldTypePrefix = "bitfield:"sv;
 
             // clang-format off
-            constexpr std::array<std::pair<std::string_view, std::string_view>, 10> kTypeNameToCpp = {{
+            constexpr auto kTypeNameToCpp = std::to_array<std::pair<std::string_view, std::string_view>>({
                 {"float32"sv, "float"sv}, 
                 {"float64"sv, "double"sv},
     
@@ -23,48 +23,48 @@ namespace field_parser {
                 {"uint16"sv, "uint16_t"sv}, 
                 {"uint32"sv, "uint32_t"sv}, 
                 {"uint64"sv, "uint64_t"sv}
-            }};
+            });
 
-            constexpr std::array<std::pair<fieldtype_t, std::string_view>, 38> kDatamapToCpp = {{
-                        {fieldtype_t::FIELD_FLOAT32, "float"sv},
-                        {fieldtype_t::FIELD_TIME, "GameTime_t"sv},
-                        {fieldtype_t::FIELD_ENGINE_TIME, "float"sv},
-                        {fieldtype_t::FIELD_FLOAT64, "double"sv},
-                        {fieldtype_t::FIELD_INT16, "int16_t"sv},
-                        {fieldtype_t::FIELD_INT32, "int32_t"sv},
-                        {fieldtype_t::FIELD_INT64, "int64_t"sv},
-                        {fieldtype_t::FIELD_UINT8, "uint8_t"sv},
-                        {fieldtype_t::FIELD_UINT16, "uint16_t"sv},
-                        {fieldtype_t::FIELD_UINT32, "uint32_t"sv},
-                        {fieldtype_t::FIELD_UINT64, "uint64_t"sv},
-                        {fieldtype_t::FIELD_BOOLEAN, "bool"sv},
-                        {fieldtype_t::FIELD_CHARACTER, "char"sv},
-                        {fieldtype_t::FIELD_VOID, "void"sv},
-                        {fieldtype_t::FIELD_STRING, "CUtlSymbolLarge"sv},
-                        {fieldtype_t::FIELD_VECTOR, "Vector"sv},
-                        {fieldtype_t::FIELD_POSITION_VECTOR, "Vector"sv},
-                        {fieldtype_t::FIELD_NETWORK_ORIGIN_CELL_QUANTIZED_VECTOR, "Vector"sv},
-                        {fieldtype_t::FIELD_DIRECTION_VECTOR_WORLDSPACE, "Vector"sv},
-                        {fieldtype_t::FIELD_NETWORK_QUANTIZED_VECTOR, "Vector"sv},
-                        {fieldtype_t::FIELD_VECTOR2D, "Vector2D"sv},
-                        {fieldtype_t::FIELD_VECTOR4D, "Vector4D"sv},
-                        {fieldtype_t::FIELD_QANGLE, "QAngle"sv},
-                        {fieldtype_t::FIELD_QANGLE_WORLDSPACE, "QAngle"sv},
-                        {fieldtype_t::FIELD_QUATERNION, "Quaternion"sv},
-                        {fieldtype_t::FIELD_CSTRING, "const char *"sv},
-                        {fieldtype_t::FIELD_UTLSTRING, "CUtlString"sv},
-                        {fieldtype_t::FIELD_UTLSTRINGTOKEN, "CUtlStringToken"sv},
-                        {fieldtype_t::FIELD_COLOR32, "Color"sv},
-                        {fieldtype_t::FIELD_WORLD_GROUP_ID, "WorldGroupId_t"sv},
-                        {fieldtype_t::FIELD_ROTATION_VECTOR, "RotationVector"sv},
-                        {fieldtype_t::FIELD_CTRANSFORM_WORLDSPACE, "CTransform"sv},
-                        {fieldtype_t::FIELD_EHANDLE, "CHandle< CBaseEntity >"sv},
-                        {fieldtype_t::FIELD_CUSTOM, "void"sv},
-                        {fieldtype_t::FIELD_HMODEL, "CStrongHandle< InfoForResourceTypeCModel >"sv},
-                        {fieldtype_t::FIELD_HMATERIAL, "CStrongHandle< InfoForResourceTypeIMaterial2 >"sv},
-                        {fieldtype_t::FIELD_SHIM, "SHIM"sv},
-                        {fieldtype_t::FIELD_FUNCTION, "void*"sv},
-                    }};
+            constexpr auto kDatamapToCpp = std::to_array<std::pair<fieldtype_t, std::string_view>>({
+                {fieldtype_t::FIELD_FLOAT32, "float"sv},
+                {fieldtype_t::FIELD_TIME, "GameTime_t"sv},
+                {fieldtype_t::FIELD_ENGINE_TIME, "float"sv},
+                {fieldtype_t::FIELD_FLOAT64, "double"sv},
+                {fieldtype_t::FIELD_INT16, "int16_t"sv},
+                {fieldtype_t::FIELD_INT32, "int32_t"sv},
+                {fieldtype_t::FIELD_INT64, "int64_t"sv},
+                {fieldtype_t::FIELD_UINT8, "uint8_t"sv},
+                {fieldtype_t::FIELD_UINT16, "uint16_t"sv},
+                {fieldtype_t::FIELD_UINT32, "uint32_t"sv},
+                {fieldtype_t::FIELD_UINT64, "uint64_t"sv},
+                {fieldtype_t::FIELD_BOOLEAN, "bool"sv},
+                {fieldtype_t::FIELD_CHARACTER, "char"sv},
+                {fieldtype_t::FIELD_VOID, "void"sv},
+                {fieldtype_t::FIELD_STRING, "CUtlSymbolLarge"sv},
+                {fieldtype_t::FIELD_VECTOR, "Vector"sv},
+                {fieldtype_t::FIELD_POSITION_VECTOR, "Vector"sv},
+                {fieldtype_t::FIELD_NETWORK_ORIGIN_CELL_QUANTIZED_VECTOR, "Vector"sv},
+                {fieldtype_t::FIELD_DIRECTION_VECTOR_WORLDSPACE, "Vector"sv},
+                {fieldtype_t::FIELD_NETWORK_QUANTIZED_VECTOR, "Vector"sv},
+                {fieldtype_t::FIELD_VECTOR2D, "Vector2D"sv},
+                {fieldtype_t::FIELD_VECTOR4D, "Vector4D"sv},
+                {fieldtype_t::FIELD_QANGLE, "QAngle"sv},
+                {fieldtype_t::FIELD_QANGLE_WORLDSPACE, "QAngle"sv},
+                {fieldtype_t::FIELD_QUATERNION, "Quaternion"sv},
+                {fieldtype_t::FIELD_CSTRING, "const char *"sv},
+                {fieldtype_t::FIELD_UTLSTRING, "CUtlString"sv},
+                {fieldtype_t::FIELD_UTLSTRINGTOKEN, "CUtlStringToken"sv},
+                {fieldtype_t::FIELD_COLOR32, "Color"sv},
+                {fieldtype_t::FIELD_WORLD_GROUP_ID, "WorldGroupId_t"sv},
+                {fieldtype_t::FIELD_ROTATION_VECTOR, "RotationVector"sv},
+                {fieldtype_t::FIELD_CTRANSFORM_WORLDSPACE, "CTransform"sv},
+                {fieldtype_t::FIELD_EHANDLE, "CHandle< CBaseEntity >"sv},
+                {fieldtype_t::FIELD_CUSTOM, "void"sv},
+                {fieldtype_t::FIELD_HMODEL, "CStrongHandle< InfoForResourceTypeCModel >"sv},
+                {fieldtype_t::FIELD_HMATERIAL, "CStrongHandle< InfoForResourceTypeIMaterial2 >"sv},
+                {fieldtype_t::FIELD_SHIM, "SHIM"sv},
+                {fieldtype_t::FIELD_FUNCTION, "void*"sv},
+            });
             // clang-format on
         } // namespace
 


### PR DESCRIPTION
1. Rename CSGO2 to CS2
2. SchemaFieldMetadataOverrideSetData_t is now alias of datamap_t
3. SchemaFieldMetadataOverrideData_t is now alias of typedescription_t
4. Added datamap_t as interface with own classes
5. SDK Gen now dumps unique offsets that were not found in schema dump
6. Fix DucaRii commit which was skipping some structures
7. Added datamap parse related to field_parser