### PR TITLE
Fixed header file names not matching their content

### DIFF
--- a/include/sdk/interfaces/common/CThreadSpinMutex.h
+++ b/include/sdk/interfaces/common/CThreadSpinMutex.h
@@ -1,20 +1,35 @@
 // Copyright (C) 2023 neverlosecc
 // See end of file for extended copyright information.
+
 #pragma once
 
-class CThreadSpinRWLock {
-public:
-    struct LockInfo_t {
-        std::uint32_t m_writerId;
-        std::int32_t m_nReaders;
-    };
+#if defined(CS2) || defined(DOTA2)
+constexpr auto kThreadSpinMutex = 2;
+#else
+constexpr auto kThreadSpinMutex = 1;
+#endif
 
+class CThreadSpinMutexV1 {
 public:
-    void* m_pThreadSpin;
-    LockInfo_t m_lockInfo;
+    CThreadSpinMutexV1(const char* pDebugName = NULL): m_ownerID(0), m_depth(0), m_pszDebugName(pDebugName) { }
+
+private:
+    volatile ThreadId_t m_ownerID;
+    int m_depth;
     const char* m_pszDebugName;
 };
-static_assert(sizeof(CThreadSpinRWLock) == 0x18);
+
+class CThreadSpinMutexV2 {
+public:
+    CThreadSpinMutexV2([[maybe_unused]] const char* pDebugName = NULL): m_ownerID(0), m_depth(0) { }
+
+private:
+    volatile ThreadId_t m_ownerID;
+    int m_depth;
+};
+
+using CThreadSpinMutex = std::conditional_t<kThreadSpinMutex == 1, CThreadSpinMutexV1, CThreadSpinMutexV2>;
+using CThreadFastMutex = CThreadSpinMutex;
 
 // source2gen - Source2 games SDK generator
 // Copyright 2023 neverlosecc

--- a/include/sdk/interfaces/common/CThreadSpinRWLock.h
+++ b/include/sdk/interfaces/common/CThreadSpinRWLock.h
@@ -1,35 +1,20 @@
 // Copyright (C) 2023 neverlosecc
 // See end of file for extended copyright information.
-
 #pragma once
 
-#if defined(CS2) || defined(DOTA2)
-constexpr auto kThreadSpinMutex = 2;
-#else
-constexpr auto kThreadSpinMutex = 1;
-#endif
-
-class CThreadSpinMutexV1 {
+class CThreadSpinRWLock {
 public:
-    CThreadSpinMutexV1(const char* pDebugName = NULL): m_ownerID(0), m_depth(0), m_pszDebugName(pDebugName) { }
+    struct LockInfo_t {
+        std::uint32_t m_writerId;
+        std::int32_t m_nReaders;
+    };
 
-private:
-    volatile ThreadId_t m_ownerID;
-    int m_depth;
+public:
+    void* m_pThreadSpin;
+    LockInfo_t m_lockInfo;
     const char* m_pszDebugName;
 };
-
-class CThreadSpinMutexV2 {
-public:
-    CThreadSpinMutexV2([[maybe_unused]] const char* pDebugName = NULL): m_ownerID(0), m_depth(0) { }
-
-private:
-    volatile ThreadId_t m_ownerID;
-    int m_depth;
-};
-
-using CThreadSpinMutex = std::conditional_t<kThreadSpinMutex == 1, CThreadSpinMutexV1, CThreadSpinMutexV2>;
-using CThreadFastMutex = CThreadSpinMutex;
+static_assert(sizeof(CThreadSpinRWLock) == 0x18);
 
 // source2gen - Source2 games SDK generator
 // Copyright 2023 neverlosecc


### PR DESCRIPTION
CThreadSpinMutex.h and CThreadSpinRWLock.h did not match their content (the file names were flipped)