### PR TITLE
Forward declaration functionality minor fix

### DIFF
--- a/source2gen/include/tools/codegen.h
+++ b/source2gen/include/tools/codegen.h
@@ -232,9 +232,14 @@ namespace codegen {
 
             _forward_decls.insert(fwd_decl_hash);
 
-            // @fixme: split method to class_forward_declaration & struct_forward_declaration
-            // one for `struct uwu_t` and the other one for `class c_uwu`
-            return push_line(std::format("struct {};", text));
+            // @note: @qbibubi: classes always start with 'C' or 'C_' and
+            // there are objecsts like 'CCSPlayerPawn` that have double 'C'
+            // at the beginning so there should not be any issues
+            const auto is_class = [](std::string_view name) -> bool {
+                return (name[0] == 'C');
+            };
+
+            return push_line(is_class(text) ? std::format("class {};", text) : std::format("struct {};", text));
         }
 
         self_ref struct_padding(const std::optional<std::ptrdiff_t> pad_offset, const std::size_t padding_size, const bool move_cursor_to_next_line = true,

--- a/source2gen/include/tools/codegen.h
+++ b/source2gen/include/tools/codegen.h
@@ -10,6 +10,7 @@
 #include <type_traits>
 
 #include "tools/fnv.h"
+#include "tools/util.h"
 
 namespace codegen {
     constexpr char kSpaceSym = ' ';
@@ -238,14 +239,8 @@ namespace codegen {
 
             _forward_decls.insert(fwd_decl_hash);
 
-            // @note: @qbibubi: classes always start with 'C' or 'C_' and
-            // there are objecsts like 'CCSPlayerPawn` that have double 'C'
-            // at the beginning so there should not be any issues
-            const auto is_class = [](std::string_view name) -> bool {
-                return (name[0] == 'C');
-            };
-
-            return push_line(is_class(text) ? std::format("class {};", text) : std::format("struct {};", text));
+            const auto item_type = util::IsStruct(type_name) ? "struct" : "class";
+            return push_line(std::format("{} {};", item_type, type_name));
         }
 
         self_ref struct_padding(const std::optional<std::ptrdiff_t> pad_offset, const std::size_t padding_size, const bool move_cursor_to_next_line = true,

--- a/source2gen/include/tools/util.h
+++ b/source2gen/include/tools/util.h
@@ -38,6 +38,10 @@ namespace util {
         std::ranges::replace(result, ':', '_');
         return result;
     }
+
+    [[nodiscard]] inline bool IsStruct(std::string_view name) {
+        return name.ends_with("_t");
+    }
 } // namespace util
 
 // source2gen - Source2 games SDK generator

--- a/source2gen/src/sdk/sdk.cpp
+++ b/source2gen/src/sdk/sdk.cpp
@@ -770,7 +770,7 @@ namespace {
         const auto class_alignment = GetClassAlignmentRecursive(cache.class_alignment, class_);
         // Source2 has alignof(max_align_t)=8, i.e. every class whose size is a multiple of 8 is aligned.
         const auto class_is_aligned = (class_size % class_alignment.value_or(source2_max_align)) == 0;
-        const auto is_struct = std::string_view{class_.m_pszName}.ends_with("_t");
+        const auto is_struct = util::IsStruct(class_.m_pszName);
 
         if (!class_is_aligned) {
             const auto warning = [&]() {


### PR DESCRIPTION
Fixed functionality which previously declared all forward declarations as `struct`. New functionality distinguishes classes from structures by checking passed objects name for occurence of `C` as the first character.
```cpp
// Forward declaration for stucture
namespace source2sdk::entity2
{
	struct EntComponentInfo_t;
};

// Example forward declarations for different names of classes
namespace source2sdk::client
{
	class C_BaseModelEntity;
};

namespace source2sdk::soundsystem_voicecontainers
{
	class CVoiceContainerAnalysisBase;
};

namespace source2sdk::server
{
	class CCSPlayerPawn;
};
```