### PR TITLE
sdk-static update

### DIFF
--- a/sdk-static/include/source2sdk/source2gen.hpp
+++ b/sdk-static/include/source2sdk/source2gen.hpp
@@ -21,6 +21,7 @@ using CNetworkedQuantizedFloat = char[0x08];
 using CParticleNamedValueRef = char[0x40];
 using CPiecewiseCurve = char[0x40];
 using CPlayerSlot = char[0x04];
+// size is 8 bytes bigger in Deadlock
 using CPulseValueFullType = char[0x10];
 using CResourceName = char[0xe0];
 using CSplitScreenSlot = char[0x04];
@@ -47,8 +48,7 @@ template <typename>
 using C_NetworkUtlVectorBase = char[0x18];
 template <typename>
 using CNetworkUtlVectorBase = char[0x18];
-// size unknown. only used in dynamic containers.
-using CSoundEventName = char[0x01];
+using CSoundEventName = char[0x10];
 template <typename>
 using CUtlLeanVector = char[0x10];
 template <typename, class>
@@ -100,6 +100,16 @@ using CSmartPropVariableComparison = char[0x20];
 using CSmartPropAttributeAngles = char[0x40];
 using CSmartPropAttributeStateName = char[0x40];
 using CSmartPropAttributeVariableValue = char[0x40];
+using Range_t = char[0x8];
+using V_uuid_t = char[0x10];
+using CAnimGraphTagOptionalRef = char[0x18];
+using CPanoramaImageName = char[0x10];
+using CAnimGraphTagRef = char[0x18];
+using CAttachmentNameSymbolWithStorage = char[0x20];
+using CGlobalSymbolCaseSensitive = char[0x8];
+using CKV3MemberNameSet = char[0x10];
+using CSmartPropAttributeMaterialName = char[0x40];
+using PulseSymbol_t = char[0x10];
 using Color = char[0x04];
 using DegreeEuler = char[0x0c];
 using FourVectors = char[0x30];
@@ -111,9 +121,6 @@ using QAngle = char[0x0c];
 using QuaternionStorage = char[0x10];
 using Quaternion = char[0x10];
 using RadianEuler = char[0x0c];
-using RenderInputLayoutField_t = char[0x04];
-// we don't have a field size for this type. uses the fallback of 1.
-using RenderPrimitiveType_t = char[0x01];
 using RotationVector = char[0x0c];
 template <typename>
 using SphereBase_t = char[0x10];


### PR DESCRIPTION
Removed due to them being exposed in the schema:
- RenderInputLayoutField_t
- RenderPrimitiveType_t

New types:
- Range_t 
- V_uuid_t 
- CAnimGraphTagOptionalRef 
- CPanoramaImageName 
- CAnimGraphTagRef 
- CAttachmentNameSymbolWithStorage 
- CGlobalSymbolCaseSensitive 
- CKV3MemberNameSet 
- CSmartPropAttributeMaterialName 
- PulseSymbol_t 

Other changes:
- The size of CSoundEventName is now known
- Added a clue which allows compiling for Deadlock. Perhaps sdk-static should also be game dependent?