### PR TITLE
feature: Enhance memory allocation and SDK generation

### DIFF
--- a/source2gen/include/sdk/interfaces/tier0/IMemAlloc.h
+++ b/source2gen/include/sdk/interfaces/tier0/IMemAlloc.h
@@ -40,7 +40,7 @@ public:
     }
 };
 
-extern IMemAlloc* GetMemAlloc();
+extern "C" __declspec(dllimport) IMemAlloc* GetMemAlloc();
 
 #if defined(_MSC_VER)
 #pragma warning(pop)


### PR DESCRIPTION
Updated `GetMemAlloc` in `IMemAlloc.h` to use `__declspec(dllimport)` for proper external linkage. Improved SDK generation in `startup.cpp` by adding support for dumping enums and classes from global type scopes.

> Note: Dumping the GlobalTypeScope is essential because it may include classes that are not explicitly registered within any specific module. This ensures complete coverage of all relevant types during SDK generation.