### PR TITLE
feat: add known-types cli argument

### DIFF
--- a/source2gen/include/options.hpp
+++ b/source2gen/include/options.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <optional>
+#include <vector>
+#include <string>
 
 namespace source2_gen {
     enum class Language {
@@ -18,6 +20,7 @@ namespace source2_gen {
         Language emit_language{};
         bool static_members{};
         bool static_assertions{};
+        std::vector<std::string> known_types{};
 
         /// @return @ref std::nullopt if "--help" was passed or parsing failed
         [[nodiscard]]

--- a/source2gen/src/options.cpp
+++ b/source2gen/src/options.cpp
@@ -29,6 +29,10 @@ std::optional<source2_gen::Options> source2_gen::Options::parse_args(int argc, c
         .default_value(false)
         .help("Don't generate static assertions for class size and field offsets (Generated SDK might not work. You can get banned for writing to wrong "
               "offsets!)");
+    parser.add_argument("--known-types")
+        .nargs(argparse::nargs_pattern::any)
+        .default_value(std::vector<std::string>{})
+        .help("List of known template types (should be in your source2gen.hpp)");
 
     try {
         parser.parse_args(argc, argv);
@@ -46,5 +50,6 @@ std::optional<source2_gen::Options> source2_gen::Options::parse_args(int argc, c
 
     return source2_gen::Options{.emit_language = language.value(),
                                 .static_members = (language.value() != Language::c_ida) && !parser.is_used("no-static-members"),
-                                .static_assertions = (language.value() != Language::c_ida) && !parser.is_used("no-static-assertions")};
+                                .static_assertions = (language.value() != Language::c_ida) && !parser.is_used("no-static-assertions"),
+                                .known_types = parser.get<std::vector<std::string>>("--known-types")};
 }

--- a/source2gen/src/sdk/sdk.cpp
+++ b/source2gen/src/sdk/sdk.cpp
@@ -10,6 +10,7 @@
 #include "tools/field_parser.h"
 #include "tools/util.h"
 #include <absl/strings/str_replace.h>
+#include <cstddef>
 #include <cstdlib>
 
 #include <algorithm>
@@ -898,6 +899,30 @@ namespace {
         std::unordered_set<std::string> skipped_fields{};
         std::list<std::pair<std::string, std::ptrdiff_t>> cached_fields{};
         std::list<cached_datamap_t> cached_datamap_fields{};
+        
+        const auto is_known_type = [&options](std::string type_name) {
+            // Checks if type name fully known including nested templates
+
+            if (options.known_types.empty())
+                return false;
+            
+            std::vector<std::string> types;
+            auto parts = type_name | std::views::split('<');
+            for (auto part : parts) {
+                std::string s(part.begin(), part.end());
+
+                s.erase(std::remove_if(s.begin(), s.end(), [](char c) {
+                    return c == '>' || std::isspace(static_cast<unsigned char>(c));
+                }), s.end());
+                if (!s.empty())
+                    types.push_back(s);
+            }
+            if (!types.empty())
+                types.pop_back();
+            return std::all_of(types.begin(), types.end(), [&options](const std::string& t) {
+                return std::find(options.known_types.begin(), options.known_types.end(), t) != options.known_types.end();
+            });
+        };
 
         for (const auto& field : class_.GetFields()) {
             // Fall back to size=1 because there are no 0-sized types.
@@ -999,7 +1024,7 @@ namespace {
                     .reset_tabs_count()
                     .prop(codegen::Prop{.type_category = GetTypeCategory(field), .type_name = var_info.m_type, .name = var_info.formatted_name()}, false)
                     .restore_tabs_count();
-            } else if (std::string{field.m_pSchemaType->m_pszName}.contains('<')) {
+            } else if (std::string{field.m_pSchemaType->m_pszName}.contains('<') && !is_known_type(field.m_pSchemaType->m_pszName)) {
                 // template type
 
                 // This is a workaround to get the size of template types right.

--- a/source2gen/src/sdk/sdk.cpp
+++ b/source2gen/src/sdk/sdk.cpp
@@ -899,21 +899,19 @@ namespace {
         std::unordered_set<std::string> skipped_fields{};
         std::list<std::pair<std::string, std::ptrdiff_t>> cached_fields{};
         std::list<cached_datamap_t> cached_datamap_fields{};
-        
+
         const auto is_known_type = [&options](std::string type_name) {
             // Checks if type name fully known including nested templates
 
             if (options.known_types.empty())
                 return false;
-            
+
             std::vector<std::string> types;
             auto parts = type_name | std::views::split('<');
             for (auto part : parts) {
                 std::string s(part.begin(), part.end());
 
-                s.erase(std::remove_if(s.begin(), s.end(), [](char c) {
-                    return c == '>' || std::isspace(static_cast<unsigned char>(c));
-                }), s.end());
+                s.erase(std::remove_if(s.begin(), s.end(), [](char c) { return c == '>' || std::isspace(static_cast<unsigned char>(c)); }), s.end());
                 if (!s.empty())
                     types.push_back(s);
             }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0e791d78-9bee-4bfb-83e0-0aa4f009ce84)
Now you can tell which types sdk can generate without comments