### PR TITLE
Fix: Undefine native linux definition

### DIFF
--- a/source2gen/include/tools/platform.h
+++ b/source2gen/include/tools/platform.h
@@ -2,7 +2,12 @@
 // See end of file for extended copyright information.
 #pragma once
 
-#undef linux
+/// Some environments automatically define the bare macro `linux` (in
+/// addition to the portable feature-test macro `__linux__`). This pollutes 
+/// the global namespace and collides with our `platform::linux`.
+#if defined(linux)
+    #undef linux
+#endif
 
 #define WINDOWS 0
 #define LINUX 1


### PR DESCRIPTION
Before:
```
/home/bubbles/Environment/source2gen/source2gen/include/tools/platform.h:35:15: error: expected unqualified-id before numeric constant
   35 |     platform::linux;
      |          
```
      
After:
```
[ 90%] Linking CXX executable ../bin/source2gen
[ 90%] Built target source2gen
[100%] Linking CXX executable ../../bin/source2gen-test
[100%] Built target source2gen-test
```

Also there were a billion errors regarding the linux enum but I just chose one that specifically mentioned the enum