### PR TITLE
Fix dumping for cs2

### DIFF
--- a/source2gen/include/sdk/interfaces/schemasystem/schema.h
+++ b/source2gen/include/sdk/interfaces/schemasystem/schema.h
@@ -653,9 +653,6 @@ public:
     int m_nSizeOf; // 0x0018
 
     std::int16_t m_nFieldSize; // 0x001C
-#if defined(CS2)
-    std::int16_t m_nStaticFieldsSize; // 0x001E
-#endif
 
     std::int16_t m_nStaticMetadataSize; // 0x0020
     std::uint8_t m_unAlignOf; // 0x0022
@@ -667,10 +664,6 @@ public:
     std::int16_t m_nSingleInheritanceDepth; // 0x0026
 
     SchemaClassFieldData_t* m_pFields; // 0x0028
-
-#if defined(CS2)
-    SchemaStaticFieldData_t* m_pStaticFields; // 0x0030
-#endif
 
     SchemaBaseClassInfoData_t* m_pBaseClasses; // 0x0038
     SchemaFieldMetadataOverrideSetData_t* m_pFieldMetadataOverrides; // 0x0040
@@ -690,12 +683,7 @@ public:
     }
 };
 
-#if defined(CS2)
-    static_assert(offsetof(SchemaClassInfoData_t, m_pFn) == 0x68, "Offset of m_pFn should be 0x68 in CS2 configuration");
-#else
-    static_assert(offsetof(SchemaClassInfoData_t, m_pFn) == 0x60, "Offset of m_pFn should be 0x60 in non-CS2 configuration");
-#endif
-
+static_assert(offsetof(SchemaClassInfoData_t, m_pFn) == 0x60, "Offset of m_pFn should be 0x60");
 
 class CSchemaClassInfo : public SchemaClassInfoData_t {
 public:
@@ -721,12 +709,6 @@ public:
     [[nodiscard]] std::vector<SchemaClassFieldData_t> GetFields() const {
         return {m_pFields, m_pFields + m_nFieldSize};
     }
-
-#if defined(CS2)
-    [[nodiscard]] std::vector<SchemaStaticFieldData_t> GetStaticFields() const {
-        return {m_pStaticFields, m_pStaticFields + m_nStaticFieldsSize};
-    }
-#endif
 
     [[nodiscard]] std::vector<SchemaMetadataEntryData_t> GetStaticMetadata() const {
         return {m_pStaticMetadata, m_pStaticMetadata + m_nStaticMetadataSize};
@@ -826,11 +808,10 @@ public:
 };
 
 #if defined(DOTA2) || defined(CS2) || defined(DEADLOCK)
-    static_assert(sizeof(CSchemaPtrMap<int, int>) == platform_specific{.windows = 0x28, .linux = 0x30}.get());
+static_assert(sizeof(CSchemaPtrMap<int, int>) == platform_specific{.windows = 0x28, .linux = 0x30}.get());
 #else
-    static_assert(sizeof(CSchemaPtrMap<int, int>) == platform_specific{.windows = 0x30, .linux = 0x30}.get());
+static_assert(sizeof(CSchemaPtrMap<int, int>) == platform_specific{.windows = 0x30, .linux = 0x30}.get());
 #endif
-
 
 class CSchemaSystemTypeScope {
 public:

--- a/source2gen/src/sdk/sdk.cpp
+++ b/source2gen/src/sdk/sdk.cpp
@@ -716,13 +716,6 @@ namespace {
             result.insert(names.begin(), names.end());
         }
 
-#if defined(CS2)
-        for (const auto& field : std::span{class_.m_pStaticFields, static_cast<std::size_t>(class_.m_nStaticFieldsSize)}) {
-            const auto names = GetRequiredNamesForType(*field.m_pSchemaType);
-            result.insert(names.begin(), names.end());
-        }
-#endif
-
         if (const auto* base_classes = class_.m_pBaseClasses; base_classes != nullptr) {
             assert(base_classes->m_pClass->m_pSchemaType != nullptr && "didn't think this could happen, feel free to touch");
             // source2gen doesn't support multiple inheritance, only check class[0]
@@ -1066,29 +1059,9 @@ namespace {
                                                  -end_pad, last_field_end, class_.GetName(), class_size)};
         }
 
-#if defined(CS2)
-        // @note: @es3n1n: dump static fields
-        //
-        if (class_.m_nStaticFieldsSize) {
-            if (class_.m_nFieldSize)
-                generator.next_line();
-            generator.comment("Static fields:");
-        }
-#endif
-
         // The current class may be defined in multiple scopes. It doesn't matter which one we use, as all definitions are the same..
         // TODO: verify the above statement. Are static fields really shared between scopes?
         const std::string scope_name{class_.m_pTypeScope->BGetScopeName()};
-
-#if defined(CS2)
-        for (auto s = 0; s < class_.m_nStaticFieldsSize; s++) {
-            auto static_field = &class_.m_pStaticFields[s];
-
-            auto [type_name, mod] = GetType(generator, *static_field->m_pSchemaType);
-            const auto var_info = field_parser::parse(generator, type_name, static_field->m_pszName, mod);
-            generator.static_field_getter(var_info.m_type, var_info.m_name, scope_name, class_.m_pszName, s);
-        }
-#endif
 
         if (class_.m_pFieldMetadataOverrides && class_.m_pFieldMetadataOverrides->m_iTypeDescriptionCount > 1) {
             const auto& dm = class_.m_pFieldMetadataOverrides;


### PR DESCRIPTION
In a recent update Valve finally also removed anything related to static fields inside of SchemaClassInfoData_t from CS2