### PR TITLE
fix: Deadlock dump on Windows

### DIFF
--- a/source2gen/include/sdk/interfaces/common/CThreadMutex.h
+++ b/source2gen/include/sdk/interfaces/common/CThreadMutex.h
@@ -12,7 +12,7 @@ typedef std::uint32_t ThreadId_t;
 typedef std::uint64_t ThreadId_t;
 #endif
 
-#if DOTA2 && TARGET_OS == WINDOWS
+#if (DOTA2 || DEADLOCK) && TARGET_OS == WINDOWS
 constexpr auto kTtSizeofCriticalsection = 4;
 #else
 constexpr auto kTtSizeofCriticalsection = 40;
@@ -28,7 +28,7 @@ public:
     bool m_bTrace;
     const char* m_pDebugName;
 };
-#if DOTA2 && TARGET_OS == WINDOWS
+#if (DOTA2 || DEADLOCK) && TARGET_OS == WINDOWS
 static_assert(sizeof(CThreadMutex) == platform_specific{.windows = 0x18, .linux = 0x40});
 #else
 static_assert(sizeof(CThreadMutex) == platform_specific{.windows = 0x38, .linux = 0x40});

--- a/source2gen/include/sdk/interfaces/common/CUtlMemoryPoolBase.h
+++ b/source2gen/include/sdk/interfaces/common/CUtlMemoryPoolBase.h
@@ -101,7 +101,7 @@ public:
     int m_TotalSize{}; // m_BlocksPerBlob * (m_NumBlobs + 1) + (m_nAligment + 14)
 };
 
-#if DOTA2 && TARGET_OS == WINDOWS
+#if (DOTA2 || DEADLOCK) && TARGET_OS == WINDOWS
 static_assert(sizeof(CUtlMemoryPoolBaseV2) == platform_specific{.windows = 0x60, .linux = 0x90});
 #else
 static_assert(sizeof(CUtlMemoryPoolBaseV2) == platform_specific{.windows = 0x80, .linux = 0x90});

--- a/source2gen/include/sdk/interfaces/common/CUtlTSHash.h
+++ b/source2gen/include/sdk/interfaces/common/CUtlTSHash.h
@@ -249,7 +249,7 @@ public:
 
     class HashBucket_t {
     public:
-#if DOTA2 && TARGET_OS == WINDOWS
+#if (DOTA2 || DEADLOCK) && TARGET_OS == WINDOWS
         RTL_SRWLOCK m_AddLock; // 0x0000
 #else
         CThreadSpinRWLock m_AddLock; // 0x0000
@@ -260,7 +260,7 @@ public:
     }; // Size: 0x0028
     // clang-19 requires an explicit template type for platform_specific
 
-#if DOTA2 && TARGET_OS == WINDOWS
+#if (DOTA2 || DEADLOCK) && TARGET_OS == WINDOWS
     static_assert(sizeof(HashBucket_t) == platform_specific<int>{.windows = 0x18, .linux = 0x30}); // Linux UNTESTED
 #else
     static_assert(sizeof(HashBucket_t) == platform_specific<int>{.windows = 0x28, .linux = 0x30});

--- a/source2gen/include/sdk/interfaces/schemasystem/schema.h
+++ b/source2gen/include/sdk/interfaces/schemasystem/schema.h
@@ -133,12 +133,16 @@ enum {
 
 constexpr auto kSchemaSystemVersion = platform_specific{.windows = 2, .linux = 1}.get();
 
-#if DOTA2 && TARGET_OS == WINDOWS
+#if (DOTA2 || DEADLOCK) && TARGET_OS == WINDOWS
 constexpr auto kSchemaSystem_PAD0 = platform_specific{.windows = 0x190, .linux = 0x188 + 0x68}.get();
 #else
 constexpr auto kSchemaSystem_PAD0 = platform_specific{.windows = 0x188, .linux = 0x188 + 0x68}.get();
 #endif
+#if defined(DEADLOCK) && TARGET_OS == WINDOWS
+constexpr auto kSchemaSystem_PAD1 = 0xE0;
+#else
 constexpr auto kSchemaSystem_PAD1 = 0x120;
+#endif
 constexpr auto kSchemaSystemTypeScope_PAD0 = 0x7;
 
 enum {
@@ -980,7 +984,7 @@ private:
     CSchemaType_NoschemaType m_pNoschemaType = {};
 #endif
 
-#if DOTA2 && TARGET_OS == WINDOWS
+#if (DOTA2 || DEADLOCK) && TARGET_OS == WINDOWS
     void* unk; // 0x0558
 #endif
     CUtlTSHash<CSchemaClassBinding*> m_ClassBindings = {}; // 0x0560


### PR DESCRIPTION
Running source2gen against Deadlock was returning zero bindings — the
generator walked every type scope but iterated empty hashtables.

Deadlock on Windows uses the same compact layout DOTA2 uses on Windows:
a 4-byte CRITICAL_SECTION stub in CThreadMutex, RTL_SRWLOCK inside
CUtlTSHash buckets, and the matching smaller CUtlMemoryPoolBase. The
existing `#if DOTA2 && TARGET_OS == WINDOWS` guards didn't include
Deadlock, so every struct size was off by enough bytes that
m_ClassBindings landed before its real offset of 0x560.

Extended those guards to `(DOTA2 || DEADLOCK) && TARGET_OS == WINDOWS`
in CThreadMutex.h, CUtlMemoryPoolBase.h, CUtlTSHash.h and schema.h
(the latter also picks up `kSchemaSystem_PAD0 = 0x190` and the trailing
`void* unk` in CSchemaSystemTypeScope). Split `kSchemaSystem_PAD1` per
game — Deadlock's stat counters sit at +0x280 instead of +0x2C0.

Verified: dump now completes with 11,387 registrations across 30+
modules (client: 374 enums / 3218 classes, server: 96 / 3323). Spot
checked C_CitadelPlayerPawn::m_angEyeAngles (0x11B0) and m_flRespawnTime
(0x130C) against live game memory.